### PR TITLE
[160153](164606) fix notifications to wrap the line also on page breaks

### DIFF
--- a/src/clr-addons/notification/notification.scss
+++ b/src/clr-addons/notification/notification.scss
@@ -51,6 +51,9 @@
 
         .alert-item {
           justify-content: left;
+          .alert-text {
+            white-space: pre-wrap;
+          }
         }
       }
       .alert-icon-wrapper {


### PR DESCRIPTION
detail: if the message keys are specified in the following way:
"message first line \n message second line" the notification component should wrap correctly