### PR TITLE
Run notification timers outside the angular zone

### DIFF
--- a/src/clr-addons/notification/scheduler-utils.ts
+++ b/src/clr-addons/notification/scheduler-utils.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { asyncScheduler, interval, Observable, SchedulerLike, Subscription, timer } from 'rxjs';
+import { NgZone } from '@angular/core';
+import { observeOn } from 'rxjs/operators';
+
+/**
+ * Scheduler that runs outside the angular zone
+ */
+class OutsideAngularZoneScheduler implements SchedulerLike {
+  constructor(private zone: NgZone, private scheduler: SchedulerLike) {}
+
+  now(): number {
+    return this.scheduler.now();
+  }
+
+  schedule(...args: any[]): Subscription {
+    return this.zone.runOutsideAngular(() => this.scheduler.schedule.apply(this.scheduler, args));
+  }
+}
+
+/**
+ * Scheduler that runs inside the angular zone
+ */
+class InsideAngularZoneScheduler implements SchedulerLike {
+  constructor(private zone: NgZone, private scheduler: SchedulerLike) {}
+
+  now(): number {
+    return this.scheduler.now();
+  }
+
+  schedule(...args: any[]): Subscription {
+    return this.zone.run(() => this.scheduler.schedule.apply(this.scheduler, args));
+  }
+}
+
+/**
+ * Runs a timer outside of the angular zone and executes the subscription inside the angular zone.
+ */
+export function zonedTimer(dueTime: number | Date, zone: NgZone): Observable<number> {
+  return timer(dueTime, new OutsideAngularZoneScheduler(zone, asyncScheduler)).pipe(
+    observeOn(new InsideAngularZoneScheduler(zone, asyncScheduler))
+  );
+}
+
+/**
+ * Runs a interval outside of the angular zone and executes the subscription inside the angular zone.
+ */
+export function zonedInterval(period: number, zone: NgZone): Observable<number> {
+  return interval(period, new OutsideAngularZoneScheduler(zone, asyncScheduler)).pipe(
+    observeOn(new InsideAngularZoneScheduler(zone, asyncScheduler))
+  );
+}


### PR DESCRIPTION
This makes tests that wait for Angular to become stable not stuck when a
notification is open.