### PR TITLE
Fix multiple decorators for ivy compiler

### DIFF
--- a/src/clr-addons/paged-search-result-list/paged-search-result-list.ts
+++ b/src/clr-addons/paged-search-result-list/paged-search-result-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Porsche Informatik. All Rights Reserved.
+ * Copyright (c) 2018-2020 Porsche Informatik. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -35,8 +35,10 @@ export class ClrPagedSearchResultList {
    * The template how each item should be displayed.
    */
   @Input('clrItemTemplate')
+  itemTemplateInput: TemplateRef<any>;
+
   @ContentChild(TemplateRef, { static: true })
-  itemTemplate: TemplateRef<any>;
+  itemTemplateContent: TemplateRef<any>;
 
   /**
    * The position of the pager
@@ -47,4 +49,8 @@ export class ClrPagedSearchResultList {
    * Triggered whenever a page change occurs.
    */
   @Output('clrPageChange') pageChange: EventEmitter<any> = new EventEmitter();
+
+  get itemTemplate(): TemplateRef<any> {
+    return this.itemTemplateInput || this.itemTemplateContent;
+  }
 }


### PR DESCRIPTION
In Ivy, it is not allowed to have a @Input and @ContentChild decorator on
the same property. We should use two dedicated properties and check which
one is set when using them.

https://github.com/angular/angular/issues/31398