### PR TITLE
fix: color for PHS theme in different places

### DIFF
--- a/src/clr-addons/themes/phs/variables.color.scss
+++ b/src/clr-addons/themes/phs/variables.color.scss
@@ -1,3 +1,5 @@
+$clr-color-hue: 183.2;
+
 :root {
   --blue-light: #e6f3f8;
   --blue-mid: #85c3df;


### PR DESCRIPTION
This fixes the color for the PHS theme for progress spinner, radio button group and probably other places.