### PR TITLE
Forms: fix asterisk for required labels line-breaking

### DIFF
--- a/src/clr-addons/components.clr-addons.scss
+++ b/src/clr-addons/components.clr-addons.scss
@@ -202,11 +202,13 @@ body,
 }
 
 form .required:after {
+  position: absolute;
   content: '*';
   font-size: 0.58479532rem; // Approximately 14px.
   line-height: 0.5rem;
   color: var(--red-dark);
   margin-left: 0.25rem;
+  margin-top: 0.25rem;
 }
 
 // Readonly checkboxes, radiobuttons


### PR DESCRIPTION
If the content of a label is written on a separate line than the closing tag of the label, ie.
```
<label>
  text content of the label
</label>
```
then the newline after the text content is causing the asterisk for 'required' labels to line-break.

![image](https://user-images.githubusercontent.com/16322387/86765498-884b4000-c049-11ea-884c-78bd4a2f11c8.png)

This change ensures the asterisk always stays on the same line as the last character of the label.