### PR TITLE
Forms: fix asterisk for required labels when there is no relative parent available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2137,9 +2137,9 @@
       }
     },
     "@clr/angular": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@clr/angular/-/angular-3.1.1.tgz",
-      "integrity": "sha512-d+DbUVjls/mqQ81b0jxp16g2D+BK+1bSIDx5qaf67qKfDhc8dTdADl7BwxGb1V7jz9WUHihg8W4W/8jVhOpJrg=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@clr/angular/-/angular-3.1.3.tgz",
+      "integrity": "sha512-PB8onZNg3Rwg9F03Di5q6+Vk8Kj1Sc3qmJCw/DpToYcg60uubN10hQeEp4ZOIlAm8cD3zpW9tLqwfvXPj0hrAg=="
     },
     "@clr/city": {
       "version": "1.1.0",
@@ -2148,9 +2148,9 @@
       "optional": true
     },
     "@clr/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@clr/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-mGz29H70a7FIDuwcYtnoeLV3dutIBXkPBbXBCPGx55IJlUXSDnYGF86ytqd4ftRhCW2AcrAkYWNBPnOXTCSBNg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@clr/core/-/core-3.1.3.tgz",
+      "integrity": "sha512-gdhgiUZiHO7j11hhdqRxLXGZLoGrWBYwU1x4rpAjUgod8HBC+OxnWa2bPvfZKs9Avf5msJWr5tUiqGu+FNv0vw==",
       "requires": {
         "@clr/city": "^1.0.0",
         "@webcomponents/custom-elements": "^1.3.1",
@@ -2164,14 +2164,14 @@
       }
     },
     "@clr/icons": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@clr/icons/-/icons-3.1.1.tgz",
-      "integrity": "sha512-kvf9r6vAueR744HnVOYx6go+dwlxqlf1aXIWBdNfw28hFFla5ajaRvRsfCU3qro/osTxFue1RYz/8M1OCj5V6A=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@clr/icons/-/icons-3.1.3.tgz",
+      "integrity": "sha512-A1qcCISWMg3rEiD9wwdf0c62t4cUAsnexWhFEHi514vyIzwHUFizFFIAOEbbcfZ263it/qbgxNA+MiH1oo7SqQ=="
     },
     "@clr/ui": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@clr/ui/-/ui-3.1.1.tgz",
-      "integrity": "sha512-/qk7CyEsCx6/UFcpNQi6Jidf1HB+fJqSJHkf3zzelypiahO34JDi+bjZNI65oOSF04DuUYVmtHK4BrOOB508Ww=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@clr/ui/-/ui-3.1.3.tgz",
+      "integrity": "sha512-Z38f5J3cGW1oLUgvxXr5KJRzVpB8nCqM30BW+8gk+UWaIglFrtw5G30zb3FrErn/79AXorTm3Otuk/ZPQGgE3w=="
     },
     "@istanbuljs/schema": {
       "version": "0.1.2",
@@ -2973,9 +2973,9 @@
       "optional": true
     },
     "@webcomponents/shadycss": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.6.tgz",
-      "integrity": "sha512-5fFjvP0jQJZoXK6YzYeYcIDGJ5oEsdjr1L9VaYLw5yxNd4aRz4srMpwCwldeNG0A6Hvr9igbG7fCsBeiiCXd7A==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.0.tgz",
+      "integrity": "sha512-UMS+dF4DXDrcUmQqK6aLd/3mFyfGktKG/hZR6FtrsQK/INO07G0H8FxElLkuvHj0iePeZGpR7R4lWFTvX7rc9g==",
       "optional": true
     },
     "@webcomponents/webcomponentsjs": {
@@ -5207,8 +5207,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -5229,14 +5228,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5251,20 +5248,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -5381,8 +5375,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -5394,7 +5387,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -5409,7 +5401,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -5417,14 +5408,12 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -5443,7 +5432,6 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -5505,8 +5493,7 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -5534,8 +5521,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -5547,7 +5533,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -5625,8 +5610,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -5662,7 +5646,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5682,7 +5665,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -5726,14 +5708,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -7582,9 +7562,9 @@
       }
     },
     "css-vars-ponyfill": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/css-vars-ponyfill/-/css-vars-ponyfill-2.3.0.tgz",
-      "integrity": "sha512-3f8nyk9tLbpQMaSSMIQKTPplBNF44E/uxmbqq9LC3TETK5Q0eX1FabpDi6QdztDBGEkW7qBamxi/F6qOV90brA=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/css-vars-ponyfill/-/css-vars-ponyfill-2.3.2.tgz",
+      "integrity": "sha512-XkZfj0ROhem0Zdv44+LF15COsYmxnqL7Wd/gvwuWAauYoALbt2x94b6dIKF9fB6SIyOMYEQngA82t9RnC6b/aw=="
     },
     "css-what": {
       "version": "3.2.1",
@@ -22173,8 +22153,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -22202,7 +22181,6 @@
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -22217,8 +22195,7 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -22229,8 +22206,7 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -22347,8 +22323,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -22360,7 +22335,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -22375,7 +22349,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -22383,14 +22356,12 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -22409,7 +22380,6 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -22471,8 +22441,7 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -22500,8 +22469,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -22513,7 +22481,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -22591,8 +22558,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -22628,7 +22594,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -22648,7 +22613,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -22692,14 +22656,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "private": true,
   "scripts": {
     "build:ui:css": "sass --source-map --precision=8 ./src/clr-addons/themes/clr-ui/clr-ui.scss ./dist/clr-addons/styles/clr-ui.css && sass --source-map --precision=8 ./src/clr-addons/themes/clr-ui-dark/clr-ui-dark.scss ./dist/clr-addons/styles/clr-ui-dark.css && sass --source-map --precision=8 ./src/clr-addons/themes/phs/phs-theme.scss ./dist/clr-addons/styles/clr-addons-phs.css",
@@ -42,10 +42,10 @@
     "@angular/platform-browser": "9.1.4",
     "@angular/platform-browser-dynamic": "9.1.4",
     "@angular/router": "9.1.4",
-    "@clr/angular": "3.1.1",
-    "@clr/core": "3.1.1",
-    "@clr/icons": "3.1.1",
-    "@clr/ui": "3.1.1",
+    "@clr/angular": "3.1.3",
+    "@clr/core": "3.1.3",
+    "@clr/icons": "3.1.3",
+    "@clr/ui": "3.1.3",
     "core-js": "3.6.5",
     "rxjs": "6.5.5",
     "tslib": "1.11.1",

--- a/src/clr-addons/components.clr-addons.scss
+++ b/src/clr-addons/components.clr-addons.scss
@@ -201,14 +201,28 @@ body,
   }
 }
 
-form .required:after {
-  position: absolute;
-  content: '*';
-  font-size: 0.58479532rem; // Approximately 14px.
-  line-height: 0.5rem;
-  color: var(--red-dark);
-  margin-left: 0.25rem;
-  margin-top: 0.25rem;
+@mixin required-asterisk($color: var(--red-dark)) {
+  position: relative;
+
+  &:after {
+    position: absolute;
+    content: '*';
+    font-size: 0.58479532rem; // Approximately 14px.
+    line-height: 0.5rem;
+    color: $color;
+    margin-left: 0.25rem;
+    margin-top: 0.25rem;
+  }
+}
+
+form {
+  .required {
+    @include required-asterisk;
+  }
+
+  .required-multiple {
+    @include required-asterisk(var(--orange-light));
+  }
 }
 
 // Readonly checkboxes, radiobuttons

--- a/src/clr-addons/package.json
+++ b/src/clr-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/clr-addons",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "Addon components for Clarity Angular",
   "es2015": "esm2015/clr-addons.js",
   "homepage": "https://porscheinformatik.github.io/clarity-addons/",
@@ -24,10 +24,10 @@
     "@angular/forms": "^9.0.0",
     "@angular/platform-browser": "^9.0.0",
     "@angular/platform-browser-dynamic": "^9.0.0",
-    "@clr/angular": "3.1.1",
-    "@clr/core": "3.1.1",
-    "@clr/icons": "3.1.1",
-    "@clr/ui": "3.1.1"
+    "@clr/angular": "3.1.3",
+    "@clr/core": "3.1.3",
+    "@clr/icons": "3.1.3",
+    "@clr/ui": "3.1.3"
   },
   "author": "porscheinformatik",
   "license": "MIT",

--- a/src/clr-addons/themes/phs/variables.color.scss
+++ b/src/clr-addons/themes/phs/variables.color.scss
@@ -28,6 +28,7 @@ $clr-color-hue: 183.2;
 
   --orange-dark: #d25617;
   --orange-darker: #b84b14;
+  --orange-light: #ffae42;
 
   --yellow-light: #efd603;
 


### PR DESCRIPTION
Required asterisks would lock onto the window when there is no parent with position: relative available. This hotfix makes sure there always is one.