### PR TITLE
Fix command bar dropdown menus z-index

### DIFF
--- a/src/clr-addons/components.clr-addons.scss
+++ b/src/clr-addons/components.clr-addons.scss
@@ -52,10 +52,6 @@ body,
     flex: 1 0 auto;
     justify-content: flex-end;
     align-items: flex-start;
-
-    .dropdown-menu {
-      z-index: map-get($clr-layers, sidepanel) - 2;
-    }
   }
 }
 


### PR DESCRIPTION
This restores the default z-index of dropdown menus so that it will show in front of the content panel.

Closes #852