### PR TITLE
Fix styling bugs that occurred during clarity upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "10.1.5",
+  "version": "10.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "10.1.5",
+  "version": "10.1.6",
   "private": true,
   "scripts": {
     "build:ui:css": "sass --source-map --precision=8 ./src/clr-addons/themes/phs/phs-theme.scss ./dist/clr-addons/styles/clr-addons-phs.css",

--- a/src/clr-addons/components.clr-addons.scss
+++ b/src/clr-addons/components.clr-addons.scss
@@ -364,24 +364,6 @@ clr-date-container .clr-control-container {
   }
 }
 
-// Set the width of the combobox to 100% so that it really fills the place it has been given
-.clr-combobox {
-  width: 100%;
-
-  .clr-combobox-wrapper {
-    width: 100%;
-
-    .clr-combobox-input {
-      width: 100%;
-    }
-  }
-}
-
-// Keeps the validation-icon on same level as the input
-.clr-combobox-form-control .clr-control-container {
-  white-space: nowrap;
-}
-
 // This avoids the disposition of the clr select arrow icon if a validation error occurs.
 .clr-error {
   .clr-select-wrapper::after {

--- a/src/clr-addons/package.json
+++ b/src/clr-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/clr-addons",
-  "version": "10.1.5",
+  "version": "10.1.6",
   "description": "Addon components for Clarity Angular",
   "es2015": "esm2015/clr-addons.js",
   "homepage": "https://porscheinformatik.github.io/clarity-addons/",

--- a/src/clr-addons/themes/phs/css.overrides.scss
+++ b/src/clr-addons/themes/phs/css.overrides.scss
@@ -6,16 +6,19 @@
   header,
   .header {
     .header-actions {
-      > .dropdown > .nav-icon {
+      > .dropdown > .nav-icon > clr-icon {
         color: var(--turquoise-darkest);
       }
-      .nav-icon {
+
+      .nav-icon > clr-icon {
         color: var(--turquoise-darkest);
       }
     }
-    .settings .nav-icon {
+
+    .settings .nav-icon > clr-icon {
       color: var(--turquoise-darkest);
     }
+
     .branding {
       min-width: 4rem;
     }
@@ -81,20 +84,25 @@
     &.is-success {
       fill: var(--clr-icon-color-success);
     }
+
     &.is-danger {
       fill: var(--clr-icon-color-danger);
     }
+
     &.is-red,
     &.is-error {
       fill: var(--clr-icon-color-error);
     }
+
     &.is-warning {
       fill: var(--clr-icon-color-warning);
     }
+
     &.is-blue,
     &.is-info {
       fill: var(--clr-icon-color-info);
     }
+
     &.is-highlight {
       fill: var(--clr-icon-color-highlight);
     }
@@ -121,18 +129,15 @@
     color: var(--clr-text-color-danger) !important;
   }
 
+  .header .header-actions > .dropdown .dropdown-toggle.nav-icon,
   .dropdown .dropdown-toggle {
-    &.btn clr-icon[shape^='caret'] {
-      right: 0.6rem;
-    }
-
     clr-icon[shape^='caret'] {
       position: absolute;
       top: 50%;
       transform: translateY(-50%);
-      color: inherit;
       height: 0.5rem;
       width: 0.5rem;
+      right: 0.6rem;
     }
   }
 }

--- a/src/dev/src/app/app.component.html
+++ b/src/dev/src/app/app.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2018-2020 Porsche Informatik. All Rights Reserved.
+  ~ Copyright (c) 2018-2021 Porsche Informatik. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -33,6 +33,7 @@
       <clr-dropdown>
         <button type="button" class="nav-icon dropdown-toggle" clrDropdownTrigger>
           <clr-icon shape="cog"></clr-icon>
+          <clr-icon shape="caret down"></clr-icon>
         </button>
         <clr-dropdown-menu clrPosition="bottom-right" *clrIfOpen>
           <button type="button" *ngFor="let theme of themes" (click)="setTheme(theme)" clrDropdownItem>
@@ -40,8 +41,20 @@
           </button>
         </clr-dropdown-menu>
       </clr-dropdown>
+
+      <!-- user menu drop down -->
+      <clr-dropdown>
+        <button type="button" class="nav-icon dropdown-toggle" clrDropdownTrigger>
+          <clr-icon shape="user"></clr-icon>
+          <clr-icon shape="caret down"></clr-icon>
+        </button>
+        <clr-dropdown-menu clrPosition="bottom-right" *clrIfOpen>
+          <h4 class="dropdown-header">Max Mustermann</h4>
+        </clr-dropdown-menu>
+      </clr-dropdown>
     </div>
   </clr-header>
+
   <clr-history-pinned [clrUsername]="'me'" [clrContext]="{ tenantId: '1' }"></clr-history-pinned>
   <div class="content-header">
     <clr-back-button></clr-back-button>

--- a/src/dev/src/app/app.component.ts
+++ b/src/dev/src/app/app.component.ts
@@ -9,7 +9,10 @@ import { APP_ROUTES } from './app.routing';
 import { isPlatformBrowser, DOCUMENT } from '@angular/common';
 import { RouteHistoryService } from './route-history.service';
 
-@Component({ selector: 'app-root', templateUrl: './app.component.html' })
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+})
 export class AppComponent implements OnInit {
   public routes: Route[] = APP_ROUTES;
   linkRef: HTMLLinkElement;

--- a/src/dev/src/app/date-time-container/date-time-container.demo.html
+++ b/src/dev/src/app/date-time-container/date-time-container.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2018-2020 Porsche Informatik. All Rights Reserved.
+  ~ Copyright (c) 2018-2021 Porsche Informatik. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -84,14 +84,26 @@
       <label for="toggle" class="clr-col-none"></label>
     </clr-toggle-wrapper>
   </clr-toggle-container>
+
   <clr-combobox-container class="clr-col-12">
-    <label>Combobox</label>
-    <clr-combobox [(ngModel)]="comboboxOption" name="combobox">
+    <label>Single Select Combobox</label>
+    <clr-combobox [(ngModel)]="comboboxOption" name="combobox" required>
       <clr-options>
         <clr-option *ngFor="let option of values$ | async" [clrValue]="option">{{option}}</clr-option>
       </clr-options>
-      <clr-control-error>Select a value</clr-control-error>
     </clr-combobox>
+    <clr-control-error>Select a value</clr-control-error>
+  </clr-combobox-container>
+
+  <clr-combobox-container class="clr-col-12">
+    <label>Multi Select Combobox</label>
+    <clr-combobox [(ngModel)]="comboboxOptions" name="combobox" required [clrMulti]="true">
+      <ng-container *clrOptionSelected="let selected"> {{selected}} </ng-container>
+      <clr-options>
+        <clr-option *clrOptionItems="let option of values2$ | async" [clrValue]="option"> {{option}} </clr-option>
+      </clr-options>
+    </clr-combobox>
+    <clr-control-error>Select 2 values</clr-control-error>
   </clr-combobox-container>
 
   <clr-datalist-container class="clr-col-12">
@@ -261,7 +273,7 @@
 
       <clr-combobox-container class="clr-row">
         <label>Combobox</label>
-        <clr-combobox [(ngModel)]="comboboxOption" name="combobox">
+        <clr-combobox [(ngModel)]="comboboxOption" name="combobox" required>
           <clr-options>
             <clr-option *ngFor="let option of values$ | async" [clrValue]="option">{{option}}</clr-option>
           </clr-options>

--- a/src/dev/src/app/date-time-container/date-time-container.demo.ts
+++ b/src/dev/src/app/date-time-container/date-time-container.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Porsche Informatik. All Rights Reserved.
+ * Copyright (c) 2018-2021 Porsche Informatik. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -12,13 +12,37 @@ import { delay } from 'rxjs/operators';
   templateUrl: './date-time-container.demo.html',
 })
 export class DateTimeContainerDemo {
-  values$ = of(['Option 4', '<na> Option 5', 'Option 6 (test)', 'Option 7']).pipe(delay(500));
+  values$ = of([
+    'Option 4',
+    '<na> Option 5',
+    'Option 6 (test)Option 6 (test)Option 6 (test)Option 6 (test)',
+    'Option 7',
+  ]).pipe(delay(500));
+  values2$ = of([
+    'Option 4',
+    '<na> Option 5',
+    'Option 6 (test)Option 6 (test)Option 6 (test)Option 6 (test)',
+    'Option 7',
+    'Option 41',
+    '<na> Option 51',
+    'Option 61 (test)',
+    'Option 71',
+    'Option 42',
+    '<na> Option 52',
+    'Option 62 (test)',
+    'Option 72',
+    'Option 43',
+    '<na> Option 53',
+    'Option 63 (test)',
+    'Option 73',
+  ]).pipe(delay(500));
 
   inputText: string;
   textareaText: string;
   passwordText: string;
   selectedOption: any;
-  comboboxOption = 'Option 7';
+  comboboxOption: string;
+  comboboxOptions: string[];
   radioOption: any;
   date: any;
   time: any;


### PR DESCRIPTION
+ Color of icons in header were no longer in theme color
+ Caret-Down-Icon misplaced and wrong size when used in header

Fix combobox issues:

+ Multiselect combobox extended across the page because of whitespace: nowrap
+ Remove the 100% width of combobox to avoid validation icon being displayed in next line