### PR TITLE
fix: breadcrumbs/history encode/decode fixing

### DIFF
--- a/src/clr-addons/history/history.service.ts
+++ b/src/clr-addons/history/history.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Porsche Informatik. All Rights Reserved.
+ * Copyright (c) 2018-2021 Porsche Informatik. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -188,14 +188,14 @@ export class ClrHistoryService {
   }
 
   private encode(content: ClrHistoryModel[]): string {
-    const jsonString = btoa(JSON.stringify(content));
+    const jsonString = btoa(encodeURIComponent(JSON.stringify(content)));
     return jsonString.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '!');
   }
 
   private decode(content: string): ClrHistoryModel[] {
     try {
       const base64 = content.replace(/-/g, '+').replace(/_/g, '/').replace(/!/g, '=');
-      return JSON.parse(atob(base64));
+      return JSON.parse(decodeURIComponent(atob(base64)));
     } catch (error) {
       return [];
     }

--- a/src/clr-addons/history/history.spec.ts
+++ b/src/clr-addons/history/history.spec.ts
@@ -65,4 +65,23 @@ describe('ClrHistory', () => {
     historyService.resetHistory();
     expect(historyService.getHistory('admin', { ['applicationName']: 'TEST' }).length).toEqual(0);
   });
+
+  it('encodeUTF8', () => {
+    const czech = 'Škoda v čínštině';
+    const chinese = '斯柯达👾';
+    const historyEntry: ClrHistoryModel = {
+      username: 'utf8',
+      context: { ['applicationName']: 'TEST' },
+      pageName: czech,
+      title: chinese,
+      url: 'url1',
+    };
+    historyService.resetHistory();
+    expect(historyService.getHistory('utf8', { ['applicationName']: 'TEST' }).length).toEqual(0);
+    historyService.addHistoryEntry(historyEntry);
+    expect(historyService.getHistory('utf8', { ['applicationName']: 'TEST' }).length).toEqual(1);
+    const lastHistoryEntry = historyService.getHistory('utf8', { ['applicationName']: 'TEST' }).pop();
+    expect(lastHistoryEntry.pageName).toEqual(czech);
+    expect(lastHistoryEntry.title).toEqual(chinese);
+  });
 });


### PR DESCRIPTION
breadcrumbs (history) has a problem on stringify non-ascii UTF-8 characters in the url.
uriEncode the value first solves the issue (and uriDecode on loading)