### PR TITLE
Fixing rounding problem for NumericField in case of 4.1 or 5.1 input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "12.1.1",
+  "version": "12.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "12.1.1",
+  "version": "12.1.2",
   "private": true,
   "scripts": {
     "build:ui:css": "sass --source-map --precision=8 ./src/clr-addons/themes/phs/phs-theme.scss ./dist/clr-addons/styles/clr-addons-phs.css",

--- a/src/clr-addons/numericfield/numeric-field.spec.ts
+++ b/src/clr-addons/numericfield/numeric-field.spec.ts
@@ -281,6 +281,34 @@ describe('NumericComponent', () => {
     expect(fixture.componentInstance.input).toBe(124);
   }));
 
+  it('Fix rounding error in case of 4.1 input', fakeAsync(() => {
+    fixture.componentInstance.decimalPlaces = 2;
+    fixture.componentInstance.input = 4.1;
+    fixture.componentInstance.rounded = false;
+    fixture.componentInstance.autofill = true;
+    fixture.detectChanges();
+
+    tick(10);
+
+    expect(inputEl.nativeElement.value).toBe('4,10');
+    expect(fixture.componentInstance.component.displayValue).toBe('4,10');
+    expect(fixture.componentInstance.input).toBe(4.1);
+  }));
+
+  it('Fix rounding error in case of 5.1 input', fakeAsync(() => {
+    fixture.componentInstance.decimalPlaces = 2;
+    fixture.componentInstance.input = 5.1;
+    fixture.componentInstance.rounded = false;
+    fixture.componentInstance.autofill = true;
+    fixture.detectChanges();
+
+    tick(10);
+
+    expect(inputEl.nativeElement.value).toBe('5,10');
+    expect(fixture.componentInstance.component.displayValue).toBe('5,10');
+    expect(fixture.componentInstance.input).toBe(5.1);
+  }));
+
   it('Issue #1378', fakeAsync(() => {
     fixture.componentInstance.decimalPlaces = 2;
     fixture.componentInstance.input = 1.13;

--- a/src/clr-addons/numericfield/numeric-field.ts
+++ b/src/clr-addons/numericfield/numeric-field.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 Porsche Informatik. All Rights Reserved.
+ * Copyright (c) 2018-2022 Porsche Informatik. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -385,6 +385,6 @@ export class ClrNumericField implements OnInit, OnDestroy, AfterViewChecked, Con
   private roundOrTruncate(value: number): number {
     const method = this.roundValue ? 'round' : value < 0 ? 'ceil' : 'floor';
     // 16 is the highest precision before numbers have weird behaviour. see https://stackoverflow.com/q/21472828/15120942
-    return Math[method](+(value * Math.pow(10, this.decimalPlaces)).toPrecision(16)) / Math.pow(10, this.decimalPlaces);
+    return Math[method](+(value * Math.pow(10, this.decimalPlaces)).toPrecision(15)) / Math.pow(10, this.decimalPlaces);
   }
 }


### PR DESCRIPTION
In case of input = 4.1 in the roundOrTruncate function "value * Math.pow(10, 2)" produces 409.99999999999994.
Same for 5.1 input.