### PR TITLE
Enhance multilang input/textarea

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clr-addons",
-  "version": "12.2.3",
+  "version": "12.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clr-addons",
-      "version": "12.2.3",
+      "version": "12.4.0",
       "hasInstallScript": true,
       "dependencies": {
         "@angular/animations": "13.3.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "12.3.1",
+  "version": "12.4.0",
   "private": true,
   "scripts": {
     "build:ui:css": "sass --source-map --precision=8 ./src/clr-addons/themes/phs/phs-theme.scss ./dist/clr-addons/styles/clr-addons-phs.css",

--- a/src/clr-addons/brand-avatar/brand-avatar.spec.ts
+++ b/src/clr-addons/brand-avatar/brand-avatar.spec.ts
@@ -5,6 +5,7 @@
  */
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ClrIconModule } from '@clr/angular';
 
 import { ClrBrandAvatar } from './brand-avatar';
 
@@ -14,6 +15,7 @@ describe('BrandAvatarComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [ClrIconModule],
       declarations: [ClrBrandAvatar],
       teardown: { destroyAfterEach: false },
     }).compileComponents();

--- a/src/clr-addons/multilingual/multilingual-input/multilingual-input.html
+++ b/src/clr-addons/multilingual/multilingual-input/multilingual-input.html
@@ -3,7 +3,7 @@
   <clr-multilingual-selector
     *ngIf="showLanguageSelector()"
     [disabled]="disabled"
-    [texts]="texts"
+    [texts]="shownTexts"
     [selectedLang]="selectedLang"
     (selectedLangChange)="changeLanguage($event)"
   >
@@ -14,7 +14,7 @@
         class="clr-input"
         type="text"
         [id]="inputId"
-        [ngModel]="!!texts && !!selectedLang ? texts.get(selectedLang) : ''"
+        [ngModel]="!!shownTexts && !!selectedLang ? shownTexts.get(selectedLang) : ''"
         (ngModelChange)="setText(selectedLang, $event)"
         (blur)="onTouch()"
         [disabled]="disabled"

--- a/src/clr-addons/multilingual/multilingual-input/multilingual-input.spec.ts
+++ b/src/clr-addons/multilingual/multilingual-input/multilingual-input.spec.ts
@@ -48,6 +48,34 @@ class TestComponentOneValid implements OnInit {
   }
 }
 
+@Component({
+  template: `
+    <clr-multilingual-input
+      [clrSelectedLang]="selectedLang"
+      [clrLanguages]="languages"
+      clrMissingPrefix="<na> "
+      clrFallbackLang="FR"
+      [(ngModel)]="data"
+      name="test"
+    >
+      <label>Test</label>
+      <clr-control-error>Error</clr-control-error>
+      <clr-control-helper>Helper</clr-control-helper>
+    </clr-multilingual-input>
+  `,
+})
+class TestComponentComplex implements OnInit {
+  selectedLang = 'EN';
+  languages = ['EN', 'DE', 'PT'];
+  data = new Map();
+
+  ngOnInit(): void {
+    this.data.set('EN', 'english text');
+    this.data.set('DE', 'deutscher text');
+    this.data.set('FR', 'texte français');
+  }
+}
+
 describe('Multilingual Input', () => {
   describe('Basic + all required', () => {
     let fixture: ComponentFixture<TestComponentAllValid>;
@@ -77,6 +105,7 @@ describe('Multilingual Input', () => {
     it('change text', () => {
       sendInput(inputEl, fixture, 'different english text');
       expect(fixture.componentInstance.data.get('EN')).toBe('different english text');
+      expect(fixture.componentInstance.data.get('DE')).toBe('deutscher text');
     });
 
     it('change text of different lang', () => {
@@ -85,6 +114,7 @@ describe('Multilingual Input', () => {
 
       sendInput(inputEl, fixture, 'anderer deutscher text');
       expect(fixture.componentInstance.data.get('DE')).toBe('anderer deutscher text');
+      expect(fixture.componentInstance.data.get('EN')).toBe('english text');
     });
 
     it('show validation error on touched', () => {
@@ -134,6 +164,91 @@ describe('Multilingual Input', () => {
     });
   });
 
+  describe('Complex tests', () => {
+    let fixture: ComponentFixture<TestComponentComplex>;
+    let inputEl: HTMLInputElement;
+    let langSelector: HTMLButtonElement;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [ClarityModule, FormsModule, ClrMultilingualModule],
+        declarations: [TestComponentComplex],
+        teardown: { destroyAfterEach: false },
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(TestComponentComplex);
+      fixture.detectChanges();
+      inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+    });
+
+    beforeEach(waitForAsync(() => {
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        langSelector = fixture.debugElement.query(By.css('.clr-multilingual-button')).nativeElement;
+      });
+    }));
+
+    it('show missing prefix -> fallback lang not present', () => {
+      fixture.componentInstance.data.delete('FR');
+      fixture.componentInstance.data = new Map(fixture.componentInstance.data);
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+        expect(fixture.componentInstance.data.size).toBe(2);
+        expect(fixture.componentInstance.data.get('EN')).toBe('english text');
+        expect(fixture.componentInstance.data.get('DE')).toBe('deutscher text');
+
+        langSelector.click();
+        fixture.detectChanges();
+
+        const langSelectorElements = getLanguageSelectorElements(fixture);
+        expect(langSelectorElements.size).toBe(2);
+        expect(langSelectorElements.get('DE')).toBe('deutscher text');
+        expect(langSelectorElements.get('PT')).toBe('<na> deutscher text');
+
+        inputEl.value = '';
+      });
+    });
+
+    it('show missing prefix -> hidden language', () => {
+      expect(fixture.componentInstance.data.size).toBe(3);
+      expect(fixture.componentInstance.data.get('EN')).toBe('english text');
+      expect(fixture.componentInstance.data.get('DE')).toBe('deutscher text');
+      expect(fixture.componentInstance.data.get('FR')).toBe('texte français');
+
+      langSelector.click();
+      fixture.detectChanges();
+
+      const langSelectorElements = getLanguageSelectorElements(fixture);
+      expect(langSelectorElements.size).toBe(2);
+      expect(langSelectorElements.get('DE')).toBe('deutscher text');
+      expect(langSelectorElements.get('PT')).toBe('<na> texte français');
+
+      inputEl.value = '';
+    });
+
+    it('leave hidden languages untouched', () => {
+      expect(fixture.componentInstance.data.size).toBe(3);
+      expect(fixture.componentInstance.data.get('EN')).toBe('english text');
+      expect(fixture.componentInstance.data.get('DE')).toBe('deutscher text');
+      expect(fixture.componentInstance.data.get('FR')).toBe('texte français');
+
+      langSelector.click();
+      fixture.detectChanges();
+
+      const langSelectorElements = getLanguageSelectorElements(fixture);
+      expect(langSelectorElements.size).toBe(2);
+      expect(langSelectorElements.get('DE')).toBe('deutscher text');
+      expect(langSelectorElements.get('PT')).toBe('<na> texte français');
+
+      sendInput(inputEl, fixture, 'different english text');
+      expect(fixture.componentInstance.data.size).toBe(3);
+      expect(fixture.componentInstance.data.get('EN')).toBe('different english text');
+      expect(fixture.componentInstance.data.get('DE')).toBe('deutscher text');
+      expect(fixture.componentInstance.data.get('FR')).toBe('texte français');
+    });
+  });
+
   function validationShown(shouldBeVisible: boolean, fixture: ComponentFixture<any>): void {
     if (shouldBeVisible) {
       expect(fixture.debugElement.query(By.css('clr-multilingual-input')).classes['clr-error']).toBeTrue();
@@ -150,5 +265,14 @@ describe('Multilingual Input', () => {
     inputEl.value = text;
     inputEl.dispatchEvent(new Event('input'));
     fixture.detectChanges();
+  }
+
+  function getLanguageSelectorElements(fixture: ComponentFixture<any>): Map<string, string> {
+    return new Map(
+      fixture.debugElement.queryAll(By.css('.clr-multilingual-dd-entry')).map(elem => {
+        const lang = (elem.children[0].nativeElement as HTMLSpanElement).innerText;
+        return [lang, (elem.nativeElement as HTMLElement).innerText.substring(lang.length)];
+      })
+    );
   }
 });

--- a/src/clr-addons/multilingual/multilingual-textarea/multilingual-textarea.html
+++ b/src/clr-addons/multilingual/multilingual-textarea/multilingual-textarea.html
@@ -3,7 +3,7 @@
   <clr-multilingual-selector
     *ngIf="showLanguageSelector()"
     [disabled]="disabled"
-    [texts]="texts"
+    [texts]="shownTexts"
     [selectedLang]="selectedLang"
     (selectedLangChange)="changeLanguage($event)"
   >
@@ -13,7 +13,7 @@
       <textarea
         class="clr-textarea"
         [id]="inputId"
-        [ngModel]="!!texts && !!selectedLang ? texts.get(selectedLang) : ''"
+        [ngModel]="!!shownTexts && !!selectedLang ? shownTexts.get(selectedLang) : ''"
         (ngModelChange)="setText(selectedLang, $event)"
         (blur)="onTouch()"
         [disabled]="disabled"

--- a/src/clr-addons/multilingual/multilingual-textarea/multilingual-textarea.spec.ts
+++ b/src/clr-addons/multilingual/multilingual-textarea/multilingual-textarea.spec.ts
@@ -48,6 +48,34 @@ class TestComponentOneValid implements OnInit {
   }
 }
 
+@Component({
+  template: `
+    <clr-multilingual-textarea
+      [clrSelectedLang]="selectedLang"
+      [clrLanguages]="languages"
+      clrMissingPrefix="<na> "
+      clrFallbackLang="FR"
+      [(ngModel)]="data"
+      name="test"
+    >
+      <label>Test</label>
+      <clr-control-error>Error</clr-control-error>
+      <clr-control-helper>Helper</clr-control-helper>
+    </clr-multilingual-textarea>
+  `,
+})
+class TestComponentComplex implements OnInit {
+  selectedLang = 'EN';
+  languages = ['EN', 'DE', 'PT'];
+  data = new Map();
+
+  ngOnInit(): void {
+    this.data.set('EN', 'english text');
+    this.data.set('DE', 'deutscher text');
+    this.data.set('FR', 'texte français');
+  }
+}
+
 describe('Multilingual Textarea', () => {
   describe('Basic + all required', () => {
     let fixture: ComponentFixture<TestComponentAllValid>;
@@ -134,6 +162,87 @@ describe('Multilingual Textarea', () => {
     });
   });
 
+  describe('Complex tests', () => {
+    let fixture: ComponentFixture<TestComponentComplex>;
+    let inputEl: HTMLInputElement;
+    let langSelector: HTMLButtonElement;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [ClarityModule, FormsModule, ClrMultilingualModule],
+        declarations: [TestComponentComplex],
+        teardown: { destroyAfterEach: false },
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(TestComponentComplex);
+      fixture.detectChanges();
+      inputEl = fixture.debugElement.query(By.css('textarea')).nativeElement;
+    });
+
+    beforeEach(waitForAsync(() => {
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        langSelector = fixture.debugElement.query(By.css('.clr-multilingual-button')).nativeElement;
+      });
+    }));
+
+    it('show missing prefix -> fallback lang not present', () => {
+      fixture.componentInstance.data.delete('FR');
+      fixture.componentInstance.data = new Map(fixture.componentInstance.data);
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+        expect(fixture.componentInstance.data.size).toBe(2);
+        expect(fixture.componentInstance.data.get('EN')).toBe('english text');
+        expect(fixture.componentInstance.data.get('DE')).toBe('deutscher text');
+
+        langSelector.click();
+        fixture.detectChanges();
+
+        const langSelectorElements = getLanguageSelectorElements(fixture);
+        expect(langSelectorElements.size).toBe(2);
+        expect(langSelectorElements.get('DE')).toBe('deutscher text');
+        expect(langSelectorElements.get('PT')).toBe('<na> deutscher text');
+      });
+    });
+
+    it('show missing prefix -> hidden language', () => {
+      expect(fixture.componentInstance.data.size).toBe(3);
+      expect(fixture.componentInstance.data.get('EN')).toBe('english text');
+      expect(fixture.componentInstance.data.get('DE')).toBe('deutscher text');
+      expect(fixture.componentInstance.data.get('FR')).toBe('texte français');
+
+      langSelector.click();
+      fixture.detectChanges();
+
+      const langSelectorElements = getLanguageSelectorElements(fixture);
+      expect(langSelectorElements.size).toBe(2);
+      expect(langSelectorElements.get('DE')).toBe('deutscher text');
+      expect(langSelectorElements.get('PT')).toBe('<na> texte français');
+    });
+
+    it('leave hidden languages untouched', () => {
+      expect(fixture.componentInstance.data.size).toBe(3);
+      expect(fixture.componentInstance.data.get('EN')).toBe('english text');
+      expect(fixture.componentInstance.data.get('DE')).toBe('deutscher text');
+      expect(fixture.componentInstance.data.get('FR')).toBe('texte français');
+
+      langSelector.click();
+      fixture.detectChanges();
+
+      const langSelectorElements = getLanguageSelectorElements(fixture);
+      expect(langSelectorElements.size).toBe(2);
+      expect(langSelectorElements.get('DE')).toBe('deutscher text');
+      expect(langSelectorElements.get('PT')).toBe('<na> texte français');
+
+      sendInput(inputEl, fixture, 'different english text');
+      expect(fixture.componentInstance.data.size).toBe(3);
+      expect(fixture.componentInstance.data.get('EN')).toBe('different english text');
+      expect(fixture.componentInstance.data.get('DE')).toBe('deutscher text');
+      expect(fixture.componentInstance.data.get('FR')).toBe('texte français');
+    });
+  });
+
   function validationShown(shouldBeVisible: boolean, fixture: ComponentFixture<any>): void {
     if (shouldBeVisible) {
       expect(fixture.debugElement.query(By.css('clr-multilingual-textarea')).classes['clr-error']).toBeTrue();
@@ -150,5 +259,14 @@ describe('Multilingual Textarea', () => {
     inputEl.value = text;
     inputEl.dispatchEvent(new Event('input'));
     fixture.detectChanges();
+  }
+
+  function getLanguageSelectorElements(fixture: ComponentFixture<any>): Map<string, string> {
+    return new Map(
+      fixture.debugElement.queryAll(By.css('.clr-multilingual-dd-entry')).map(elem => {
+        const lang = (elem.children[0].nativeElement as HTMLSpanElement).innerText;
+        return [lang, (elem.nativeElement as HTMLElement).innerText.substring(lang.length)];
+      })
+    );
   }
 });

--- a/src/clr-addons/package.json
+++ b/src/clr-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/clr-addons",
-  "version": "12.3.1",
+  "version": "12.4.0",
   "description": "Addon components for Clarity Angular",
   "es2015": "esm2015/clr-addons.js",
   "homepage": "https://porscheinformatik.github.io/clarity-addons/",

--- a/src/dev/src/app/multilingual-input/multilingual-input.demo.html
+++ b/src/dev/src/app/multilingual-input/multilingual-input.demo.html
@@ -158,3 +158,20 @@
     </tr>
   </table>
 </form>
+
+<h3>NA Handling</h3>
+<form clrForm>
+  <clr-multilingual-input
+    class="clr-col-12 clr-row"
+    clrSelectedLang="en"
+    clrMissingPrefix="<na> "
+    [clrLanguages]="['en', 'de', 'ww']"
+    [(ngModel)]="templateNA"
+    clrControlClasses="clr-col-md-9 clr-col-lg-10"
+    name="templateNA"
+  >
+    <label class="clr-col-md-3 clr-col-lg-2">Test1</label>
+    <clr-control-error>Error</clr-control-error>
+    <clr-control-helper>Helper</clr-control-helper>
+  </clr-multilingual-input>
+</form>

--- a/src/dev/src/app/multilingual-input/multilingual-input.demo.ts
+++ b/src/dev/src/app/multilingual-input/multilingual-input.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Porsche Informatik. All Rights Reserved.
+ * Copyright (c) 2018-2022 Porsche Informatik. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -16,6 +16,7 @@ export class MultilingualInputDemo implements OnInit {
   template1 = new Map();
   template2 = new Map();
   template3 = new Map();
+  templateNA = new Map();
   reactive1 = new Map();
   reactive2 = new Map();
   templateML = new Map();
@@ -37,17 +38,25 @@ export class MultilingualInputDemo implements OnInit {
     this.template1.set('en', 'english text');
     this.template1.set('de', 'deutscher text');
     this.template1.set('fr', 'texte français');
+
     this.template2.set('en', 'english text');
     this.template2.set('de', 'deutscher text');
     this.template2.set('fr', 'texte français');
+
     this.template3.set('en', 'english text');
+
     this.reactive1.set('en', 'english text');
     this.reactive1.set('de', 'deutscher text');
     this.reactive1.set('fr', 'texte français');
+
     this.reactive2.set('en', 'english text');
     this.reactive2.set('de', 'deutscher text');
     this.reactive2.set('fr', 'texte français');
+
     this.templateML.set('ww', 'Test');
     this.templateML.set('en', 'Test');
+
+    this.templateNA.set('en', 'Test');
+    this.templateNA.set('na', 'Dont show this');
   }
 }


### PR DESCRIPTION
- New input clrLanguages: Defines which languages to show, regardless of bound form model
- New input clrMissingPrefix: Prefix which will be shown, when a text in a language is misisng
- New input clrFallbackLang: Language to show text from, when a text in a language is missing