### PR TITLE
feat: add a date filter for datagrid

### DIFF
--- a/src/clr-addons/clr-addons.module.ts
+++ b/src/clr-addons/clr-addons.module.ts
@@ -33,6 +33,7 @@ import { ClrLocationBarModule } from './location-bar/location-bar.module';
 import { ClrFormModule } from './abstract-form-component/form.module';
 import { ClrDropdownOverflowModule } from './dropdown';
 import { ClrDatagridStatePersistenceModule, ClrEnumFilterModule } from './datagrid';
+import { ClrDateFilterModule } from './datagrid/date-filter/date-filter.module';
 
 @NgModule({
   exports: [
@@ -65,6 +66,7 @@ import { ClrDatagridStatePersistenceModule, ClrEnumFilterModule } from './datagr
     ClrDropdownOverflowModule,
     ClrDatagridStatePersistenceModule,
     ClrEnumFilterModule,
+    ClrDateFilterModule,
   ],
 })
 export class ClrAddonsModule {}

--- a/src/clr-addons/components.clr-addons.scss
+++ b/src/clr-addons/components.clr-addons.scss
@@ -189,6 +189,15 @@ body,
   display: none;
 }
 
+.datagrid-filter.clr-popover-content {
+  z-index: 1060;
+}
+.datagrid-filter {
+  .datagrid-date-filter-input {
+    width: 7rem;
+  }
+}
+
 // Enable highlighting of rows in a table by adding a new class 'highlight'
 .table {
   tbody {

--- a/src/clr-addons/datagrid/date-filter/date-filter.component.html
+++ b/src/clr-addons/datagrid/date-filter/date-filter.component.html
@@ -1,0 +1,21 @@
+<clr-date-container>
+  <input
+    #input_from
+    type="date"
+    name="from"
+    class="datagrid-date-filter-input"
+    [(clrDate)]="from"
+    [placeholder]="minPlaceholderValue"
+    [attr.aria-label]="minPlaceholderValue"
+  />
+</clr-date-container>
+<clr-date-container>
+  <input
+    type="date"
+    name="to"
+    class="datagrid-date-filter-input"
+    [(clrDate)]="to"
+    [placeholder]="maxPlaceholderValue"
+    [attr.aria-label]="maxPlaceholderValue"
+  />
+</clr-date-container>

--- a/src/clr-addons/datagrid/date-filter/date-filter.component.spec.ts
+++ b/src/clr-addons/datagrid/date-filter/date-filter.component.spec.ts
@@ -1,0 +1,112 @@
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ClarityModule, ClrDatagrid } from '@clr/angular';
+import { ClrDateFilterComponent } from './date-filter.component';
+
+const today = new Date(Date.now());
+const yesterday = new Date(Date.now() - 24 * 1000 * 60 * 60);
+const tomorrow = new Date(Date.now() + 24 * 1000 * 60 * 60);
+
+@Component({
+  template: `
+    <clr-datagrid>
+      <clr-dg-column [clrDgField]="'date'">
+        <clr-dg-filter>
+          <clr-date-filter clrProperty="date"></clr-date-filter>
+        </clr-dg-filter>
+      </clr-dg-column>
+
+      <clr-dg-row *clrDgItems="let data of dataList" [clrDgItem]="data">
+        <clr-dg-cell>{{ data.date }}</clr-dg-cell>
+      </clr-dg-row>
+    </clr-datagrid>
+  `,
+})
+class TestComponent {
+  dataList = [{ date: today }, { date: tomorrow }];
+
+  @ViewChild(ClrDateFilterComponent) component: ClrDateFilterComponent<{ date: Date }>;
+  @ViewChild(ClrDatagrid) datagrid: ClrDatagrid;
+}
+
+@Component({
+  template: `
+    <body>
+      <clr-datagrid>
+        <clr-dg-column [clrDgField]="'date'">
+          <clr-dg-filter>
+            <clr-date-filter clrProperty="date" [(clrFilterValue)]="filterValue"></clr-date-filter>
+          </clr-dg-filter>
+        </clr-dg-column>
+
+        <clr-dg-row *clrDgItems="let data of dataList" [clrDgItem]="data">
+          <clr-dg-cell>{{ data.name }}</clr-dg-cell>
+        </clr-dg-row>
+      </clr-datagrid>
+    </body>
+  `,
+})
+class TestComponentPreselectedValues {
+  dataList = [{ date: yesterday }, { date: today }, { date: tomorrow }];
+  filterValue = [null, today];
+
+  @ViewChild(ClrDateFilterComponent) component: ClrDateFilterComponent<{ date: Date }>;
+  @ViewChild(ClrDatagrid) datagrid: ClrDatagrid;
+}
+
+describe('DateFilterComponent', () => {
+  describe('Default', () => {
+    let fixture: ComponentFixture<TestComponent>;
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ClarityModule],
+        declarations: [TestComponent, ClrDateFilterComponent],
+        providers: [],
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(fixture.componentInstance.component).toBeTruthy();
+    });
+
+    it('filter to value', async () => {
+      expect(fixture.componentInstance.datagrid.rows.length).toBe(2);
+
+      fixture.componentInstance.component.to = today;
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.datagrid.rows.length).toBe(1);
+    });
+  });
+
+  describe('Preselected values', () => {
+    let fixture: ComponentFixture<TestComponentPreselectedValues>;
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ClarityModule],
+        declarations: [TestComponentPreselectedValues, ClrDateFilterComponent],
+        providers: [],
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TestComponentPreselectedValues);
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(fixture.componentInstance.component).toBeTruthy();
+    });
+
+    it('preselected values should be filtered', waitForAsync(() => {
+      expect(fixture.componentInstance.datagrid.rows.length).toBe(2);
+    }));
+  });
+});

--- a/src/clr-addons/datagrid/date-filter/date-filter.component.ts
+++ b/src/clr-addons/datagrid/date-filter/date-filter.component.ts
@@ -1,0 +1,140 @@
+import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { ClrCommonStringsService, ClrDatagridFilter, ClrDatagridFilterInterface } from '@clr/angular';
+import { Observable, Subject } from 'rxjs';
+import { NestedProperty } from './nested-property';
+
+@Component({
+  selector: 'clr-date-filter',
+  templateUrl: './date-filter.component.html',
+  styleUrls: ['./date-filter.component.scss'],
+})
+export class ClrDateFilterComponent<T extends { [key: string]: any }>
+  implements ClrDatagridFilterInterface<T>, OnDestroy
+{
+  private nestedProp: NestedProperty<any>;
+  @Input('clrProperty') set property(value: string) {
+    this.nestedProp = new NestedProperty(value);
+  }
+
+  constructor(filterContainer: ClrDatagridFilter, private commonStrings: ClrCommonStringsService) {
+    filterContainer.setFilter(this);
+  }
+
+  /**
+   * Provide a way to pass external placeholder and aria-label to the filter input
+   */
+  @Input('clrFilterMaxPlaceholder') maxPlaceholder: string;
+
+  get maxPlaceholderValue() {
+    return this.maxPlaceholder || this.commonStrings.keys.maxValue;
+  }
+
+  @Input('clrFilterMinPlaceholder') minPlaceholder: string;
+
+  get minPlaceholderValue() {
+    return this.minPlaceholder || this.commonStrings.keys.minValue;
+  }
+
+  @Input('clrFilterValue')
+  public set value(values: [Date, Date]) {
+    if (Array.isArray(values)) {
+      if (values && (values[0] !== this._from || values[1] !== this._to)) {
+        if (typeof values[0] === 'object') {
+          this._from = values[0];
+        } else {
+          this._from = null;
+        }
+        if (typeof values[1] === 'object') {
+          this._to = values[1];
+        } else {
+          this._to = null;
+        }
+        this._changes.next(values);
+      }
+    }
+  }
+
+  @Output('clrFilterValueChange') filterValueChange = new EventEmitter();
+
+  /**
+   * Internal values and accessor
+   */
+  private _from: Date | null = null;
+  private _to: Date | null = null;
+
+  public get from() {
+    return this._from;
+  }
+
+  public set from(from: Date) {
+    if (typeof from === 'object' && from !== this._from) {
+      if (from && typeof from.setHours === 'function') {
+        from.setHours(0, 0, 0, 0); // set from-date to start of day
+      }
+      this._from = from;
+      this._changes.next([this._from, this._to]);
+      this.filterValueChange.emit([this._from, this._to]);
+    }
+  }
+
+  public get to() {
+    return this._to;
+  }
+
+  public set to(to: Date) {
+    if (typeof to === 'object' && to !== this._to) {
+      if (to && typeof to.setHours === 'function') {
+        to.setHours(23, 59, 59, 999); // set to-date to end of day
+      }
+      this._to = to;
+      this._changes.next([this._from, this._to]);
+      this.filterValueChange.emit([this._from, this._to]);
+    }
+  }
+
+  /**
+   * Indicates if the filter is currently active, (at least one input is set)
+   */
+  public isActive(): boolean {
+    return this._from !== null || this._to !== null;
+  }
+
+  accepts(item: T): boolean {
+    const propValue = this.nestedProp.getPropValue(item);
+    if (propValue === undefined) {
+      return false;
+    }
+    if (this._from !== null && (!(propValue instanceof Date) || propValue.getTime() < this._from.getTime())) {
+      return false;
+    }
+    if (this._to !== null && (!(propValue instanceof Date) || propValue.getTime() > this._to.getTime())) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * The Observable required as part of the Filter interface
+   */
+  private _changes = new Subject<[Date, Date]>();
+  // We do not want to expose the Subject itself, but the Observable which is read-only
+  public get changes(): Observable<[Date, Date]> {
+    return this._changes.asObservable();
+  }
+
+  public get state(): any {
+    return {
+      property: this.nestedProp,
+      from: this._from,
+      to: this._to,
+    };
+  }
+
+  public equals(other: ClrDatagridFilterInterface<T, any>): boolean {
+    return other === this;
+  }
+
+  ngOnDestroy(): void {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/src/clr-addons/datagrid/date-filter/date-filter.module.ts
+++ b/src/clr-addons/datagrid/date-filter/date-filter.module.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { ClrDateFilterComponent } from './date-filter.component';
+
+@NgModule({
+  imports: [ClarityModule, CommonModule, FormsModule],
+  declarations: [ClrDateFilterComponent],
+  exports: [ClrDateFilterComponent],
+})
+export class ClrDateFilterModule {}

--- a/src/clr-addons/datagrid/date-filter/index.ts
+++ b/src/clr-addons/datagrid/date-filter/index.ts
@@ -1,0 +1,2 @@
+export * from './date-filter.component';
+export * from './date-filter.module';

--- a/src/clr-addons/datagrid/date-filter/nested-property.ts
+++ b/src/clr-addons/datagrid/date-filter/nested-property.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+/**
+ * Generic accessor for deep object properties
+ * that can be specified as simple dot-separated strings.
+ */
+export class NestedProperty<T = any> {
+  private splitProp: string[];
+
+  constructor(private prop: string) {
+    if (prop.indexOf('.') >= 0) {
+      this.splitProp = prop.split('.');
+    }
+  }
+
+  // Safe getter for a deep object property, will not throw an error but return
+  // undefined if one of the intermediate properties is null or undefined.
+  public getPropValue(item: T): any {
+    if (this.splitProp) {
+      let value = item;
+      for (const nestedProp of this.splitProp) {
+        if (
+          value === null ||
+          typeof value === 'undefined' ||
+          typeof (value as Record<string, any>)[nestedProp] === 'undefined'
+        ) {
+          return undefined;
+        }
+        value = (value as Record<string, any>)[nestedProp];
+      }
+      return value;
+    } else {
+      return (item as Record<string, any>)[this.prop];
+    }
+  }
+}

--- a/src/clr-addons/datagrid/index.ts
+++ b/src/clr-addons/datagrid/index.ts
@@ -1,2 +1,3 @@
 export * from './datagrid-state-persistence';
 export * from './enum-filter';
+export * from './date-filter';

--- a/src/dev/src/app/app.routing.ts
+++ b/src/dev/src/app/app.routing.ts
@@ -116,6 +116,11 @@ export const APP_ROUTES: Routes = [
   },
   { path: 'dropdown', loadChildren: () => import('./dropdown/dropdown.demo.module').then(m => m.DropdownDemoModule) },
   {
+    path: 'datagrid-filters',
+    loadChildren: () =>
+      import('./datagrid-filters/datagrid-filters.demo.module').then(m => m.DatagridFiltersDemoModule),
+  },
+  {
     path: 'datagrid-state-persistence',
     loadChildren: () =>
       import('./datagrid-state-persistence/datagrid-state-persistence.demo.module').then(

--- a/src/dev/src/app/datagrid-filters/clr-datagrid-filters-demo.html
+++ b/src/dev/src/app/datagrid-filters/clr-datagrid-filters-demo.html
@@ -1,0 +1,27 @@
+<h2>Datagrid filters</h2>
+
+<clr-datagrid>
+  <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
+  <clr-dg-column [clrDgField]="'amount'">
+    Amount
+    <clr-dg-numeric-filter [clrDgNumericFilter]="amountFilter"></clr-dg-numeric-filter>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'created'">
+    Created (filter={{ createdFilterValue | json }})
+    <clr-dg-filter>
+      <clr-date-filter [clrProperty]="'created'" [(clrFilterValue)]="createdFilterValue"></clr-date-filter>
+    </clr-dg-filter>
+  </clr-dg-column>
+
+  <clr-dg-row *clrDgItems="let item of items">
+    <clr-dg-cell>{{item.name}}</clr-dg-cell>
+    <clr-dg-cell>{{item.amount}}</clr-dg-cell>
+    <clr-dg-cell>{{item.created | date}}</clr-dg-cell>
+  </clr-dg-row>
+
+  <clr-dg-footer>
+    <clr-dg-pagination #pagination [clrDgPageSize]="15">
+      <clr-dg-page-size [clrPageSizeOptions]="[10,15,20,50,100]">Entries per page</clr-dg-page-size>
+    </clr-dg-pagination>
+  </clr-dg-footer>
+</clr-datagrid>

--- a/src/dev/src/app/datagrid-filters/datagrid-filters.demo.module.ts
+++ b/src/dev/src/app/datagrid-filters/datagrid-filters.demo.module.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018-2022 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+
+import { ClarityModule } from '@clr/angular';
+import { ClrAddonsModule } from '@porscheinformatik/clr-addons';
+
+import { DatagridFiltersDemo } from './datagrid-filters.demo';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ClarityModule,
+    ClrAddonsModule,
+    FormsModule,
+    RouterModule.forChild([{ path: '', component: DatagridFiltersDemo }]),
+  ],
+  declarations: [DatagridFiltersDemo],
+  exports: [DatagridFiltersDemo],
+})
+export class DatagridFiltersDemoModule {}

--- a/src/dev/src/app/datagrid-filters/datagrid-filters.demo.ts
+++ b/src/dev/src/app/datagrid-filters/datagrid-filters.demo.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { ClrDatagridNumericFilterInterface, ClrDatagridStringFilterInterface } from '@clr/angular';
+
+interface Item {
+  name: string;
+  amount: number;
+  created: Date;
+}
+
+@Component({
+  selector: 'clr-datagrid-filters-demo',
+  templateUrl: './clr-datagrid-filters-demo.html',
+})
+export class DatagridFiltersDemo {
+  items: Item[] = [
+    {
+      name: 'Item 1',
+      amount: 1,
+      created: new Date('1/1/2017'),
+    },
+    {
+      name: 'Item 2',
+      amount: 2,
+      created: new Date(),
+    },
+  ];
+  createdFilterValue = [new Date(), null];
+  titleFilter: ClrDatagridStringFilterInterface<Item> = {
+    accepts: (item: Item, search: string) => item.name && item.name.indexOf(search) > 0,
+  };
+  amountFilter: ClrDatagridNumericFilterInterface<Item> = {
+    accepts: (item: Item, low: number, high: number) => item.amount >= low && item.amount <= high,
+  };
+}


### PR DESCRIPTION
This adds a date filter which can be used in any Clarity datagrid.

Closes #1759