### PR TITLE
fix: datagrid date filter popup handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clr-addons",
-  "version": "13.4.1",
+  "version": "13.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clr-addons",
-      "version": "13.4.1",
+      "version": "13.4.2",
       "hasInstallScript": true,
       "dependencies": {
         "@angular/animations": "14.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "13.4.1",
+  "version": "13.4.2",
   "private": true,
   "scripts": {
     "build:ui:css": "sass --source-map --precision=8 ./src/clr-addons/themes/phs/phs-theme.scss ./dist/clr-addons/styles/clr-addons-phs.css",

--- a/src/clr-addons/datagrid/date-filter/date-filter.component.ts
+++ b/src/clr-addons/datagrid/date-filter/date-filter.component.ts
@@ -1,5 +1,10 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { ClrCommonStringsService, ClrDatagridFilter, ClrDatagridFilterInterface } from '@clr/angular';
+import { AfterViewInit, Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  ClrCommonStringsService,
+  ClrDatagridFilter,
+  ClrDatagridFilterInterface,
+  ClrPopoverEventsService,
+} from '@clr/angular';
 import { Observable, Subject } from 'rxjs';
 import { NestedProperty } from './nested-property';
 
@@ -8,7 +13,9 @@ import { NestedProperty } from './nested-property';
   templateUrl: './date-filter.component.html',
   styleUrls: ['./date-filter.component.scss'],
 })
-export class ClrDateFilterComponent<T extends { [key: string]: any }> implements ClrDatagridFilterInterface<T> {
+export class ClrDateFilterComponent<T extends { [key: string]: any }>
+  implements ClrDatagridFilterInterface<T>, AfterViewInit
+{
   private nestedProp: NestedProperty<any>;
 
   @Input('clrProperty') set property(value: string) {
@@ -19,8 +26,16 @@ export class ClrDateFilterComponent<T extends { [key: string]: any }> implements
     return this.nestedProp.prop;
   }
 
-  constructor(filterContainer: ClrDatagridFilter, private commonStrings: ClrCommonStringsService) {
+  constructor(
+    private commonStrings: ClrCommonStringsService,
+    private clrPopoverEventsService: ClrPopoverEventsService,
+    filterContainer: ClrDatagridFilter
+  ) {
     filterContainer.setFilter(this);
+  }
+
+  public ngAfterViewInit(): void {
+    this.clrPopoverEventsService.outsideClickClose = false;
   }
 
   /**

--- a/src/clr-addons/package.json
+++ b/src/clr-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/clr-addons",
-  "version": "13.4.1",
+  "version": "13.4.2",
   "description": "Addon components for Clarity Angular",
   "es2015": "esm2015/clr-addons.js",
   "homepage": "https://porscheinformatik.github.io/clarity-addons/",


### PR DESCRIPTION
This fixes focusing on the date picker will hide the filter popup.

Closes #1862