### PR TITLE
Forward keyup event in components for multilingual inputs

### DIFF
--- a/src/clr-addons/multilingual/abstract-multilingual.ts
+++ b/src/clr-addons/multilingual/abstract-multilingual.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 import { ClrAbstractFormComponent } from '../abstract-form-component/abstract-form-component';
-import { Directive, ElementRef, HostBinding, Injector, Input, ViewChild } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, HostBinding, Injector, Input, Output, ViewChild } from '@angular/core';
 
 @Directive()
 export abstract class ClrMultilingualAbstract extends ClrAbstractFormComponent {
@@ -14,6 +14,7 @@ export abstract class ClrMultilingualAbstract extends ClrAbstractFormComponent {
   @Input('clrSelectedLang') selectedLang: string;
   @Input() readonly: string;
   @Input() maxlength: number;
+  @Output() inputFieldKeyup = new EventEmitter<KeyboardEvent>();
   /** Show language selector when only one language provided */
   @Input('clrShowSingleLanguageSelector') showSingleLanguageSelector: boolean;
 

--- a/src/clr-addons/multilingual/multilingual-input/multilingual-input.html
+++ b/src/clr-addons/multilingual/multilingual-input/multilingual-input.html
@@ -21,6 +21,7 @@
         [readonly]="readonly || readonly === ''"
         autocomplete="off"
         [maxlength]="maxlength || null"
+        (keyup)="inputFieldKeyup.emit($event)"
         #input
       />
       <clr-icon *ngIf="showError" class="clr-validate-icon" shape="exclamation-circle" aria-hidden="true"></clr-icon>

--- a/src/clr-addons/multilingual/multilingual-textarea/multilingual-textarea.html
+++ b/src/clr-addons/multilingual/multilingual-textarea/multilingual-textarea.html
@@ -20,6 +20,7 @@
         [readonly]="readonly || readonly === ''"
         [maxlength]="maxlength || null"
         [rows]="rows || 1"
+        (keyup)="inputFieldKeyup.emit($event)"
         #input
       ></textarea>
       <clr-icon *ngIf="showError" class="clr-validate-icon" shape="exclamation-circle" aria-hidden="true"></clr-icon>

--- a/src/clr-addons/package.json
+++ b/src/clr-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/clr-addons",
-  "version": "13.4.3",
+  "version": "13.4.4",
   "description": "Addon components for Clarity Angular",
   "es2015": "esm2015/clr-addons.js",
   "homepage": "https://porscheinformatik.github.io/clarity-addons/",


### PR DESCRIPTION
Parents should be able to listen for the keyup events from the `<input>` element.

This is required for [C3DEV-45925](https://gerrit-review.porscheinformatik.com/c/products/crossng/service-base/+/73327).