### PR TITLE
Fix optional ngControl. Fixes #1906

### DIFF
--- a/src/clr-addons/searchfield/search-field.spec.ts
+++ b/src/clr-addons/searchfield/search-field.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 Porsche Informatik. All Rights Reserved.
+ * Copyright (c) 2018-2023 Porsche Informatik. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -23,57 +23,112 @@ class TestComponent {
   value: string;
 }
 
+@Component({
+  template: `<div><input clrInput clrSearch type="text" [value]="value" (input)="onInput($event)" /></div>`,
+})
+class TestWithoutModelComponent {
+  value = '';
+  onInput(e: Event) {
+    const target = e.target as HTMLInputElement;
+    this.value = target.value;
+  }
+}
+
 describe('SearchComponent', () => {
-  let fixture: ComponentFixture<TestComponent>;
-  let inputEl: DebugElement;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [ClarityModule, ClrSearchFieldModule, FormsModule],
-      declarations: [TestComponent],
-      teardown: { destroyAfterEach: false },
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(TestComponent);
-    inputEl = fixture.debugElement.query(By.css('input'));
-    fixture.detectChanges();
-  });
-
-  function addKey(key: string, keyCode: number): void {
+  function addKey(inputEl: DebugElement, key: string, keyCode: number): void {
     if (keyCode === 8) {
       inputEl.nativeElement.value = inputEl.nativeElement.value.substring(0, inputEl.nativeElement.value.length - 1);
     } else {
       inputEl.nativeElement.value += key;
     }
-    const event = document.createEvent('Event');
-    event.initEvent('input', false, false);
-    inputEl.nativeElement.dispatchEvent(event);
+    inputEl.nativeElement.dispatchEvent(new Event('input'));
   }
 
-  it('icon search rendered', () => {
-    expect(inputEl.parent.query(By.css('[shape=search]'))).toBeTruthy();
+  describe('with model', () => {
+    let fixture: ComponentFixture<TestComponent>;
+    let inputEl: DebugElement;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [ClarityModule, ClrSearchFieldModule, FormsModule],
+        declarations: [TestComponent],
+        teardown: { destroyAfterEach: false },
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(TestComponent);
+      inputEl = fixture.debugElement.query(By.css('input'));
+      fixture.detectChanges();
+    });
+
+    it('icon search rendered', () => {
+      expect(inputEl.parent.query(By.css('[shape=search]'))).toBeTruthy();
+    });
+
+    it('icon remove invisible', () => {
+      expect(getComputedStyle(inputEl.parent.query(By.css('[shape=times]')).parent.nativeElement).display).toBe('none');
+    });
+
+    it('icon remove visible', () => {
+      addKey(inputEl, '1', 49);
+      expect(getComputedStyle(inputEl.parent.query(By.css('[shape=times]')).parent.nativeElement).display).not.toBe(
+        'none'
+      );
+    });
+
+    it('icon remove working', () => {
+      addKey(inputEl, '1', 49);
+      const removeIcon = inputEl.parent.query(By.css('[shape=times]')).parent.nativeElement;
+      expect(getComputedStyle(removeIcon).display).not.toBe('none');
+      expect(fixture.componentInstance.value).toBe('1');
+
+      removeIcon.click();
+
+      expect(fixture.componentInstance.value).toBe('');
+      expect(getComputedStyle(removeIcon).display).toBe('none');
+    });
   });
 
-  it('icon remove invisible', () => {
-    expect(getComputedStyle(inputEl.parent.query(By.css('[shape=times]')).parent.nativeElement).display).toBe('none');
-  });
+  describe('without model', () => {
+    let fixture: ComponentFixture<TestWithoutModelComponent>;
+    let inputEl: DebugElement;
 
-  it('icon remove visible', () => {
-    addKey('1', 49);
-    expect(getComputedStyle(inputEl.parent.query(By.css('[shape=times]')).parent.nativeElement).display).not.toBe(
-      'none'
-    );
-  });
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [ClarityModule, ClrSearchFieldModule, FormsModule],
+        declarations: [TestWithoutModelComponent],
+        teardown: { destroyAfterEach: false },
+      }).compileComponents();
 
-  it('icon remove working', () => {
-    addKey('1', 49);
-    const removeIcon = inputEl.parent.query(By.css('[shape=times]')).parent.nativeElement;
-    expect(getComputedStyle(removeIcon).display).not.toBe('none');
-    expect(fixture.componentInstance.value).toBe('1');
+      fixture = TestBed.createComponent(TestWithoutModelComponent);
+      inputEl = fixture.debugElement.query(By.css('input'));
+      fixture.detectChanges();
+    });
 
-    removeIcon.click();
+    it('icon search rendered', () => {
+      expect(inputEl.parent.query(By.css('[shape=search]'))).toBeTruthy();
+    });
 
-    expect(fixture.componentInstance.value).toBe('');
-    expect(getComputedStyle(removeIcon).display).toBe('none');
+    it('icon remove invisible', () => {
+      expect(getComputedStyle(inputEl.parent.query(By.css('[shape=times]')).parent.nativeElement).display).toBe('none');
+    });
+
+    it('icon remove visible', () => {
+      addKey(inputEl, '1', 49);
+      expect(getComputedStyle(inputEl.parent.query(By.css('[shape=times]')).parent.nativeElement).display).not.toBe(
+        'none'
+      );
+    });
+
+    it('icon remove working', () => {
+      addKey(inputEl, '1', 49);
+      const removeIcon = inputEl.parent.query(By.css('[shape=times]')).parent.nativeElement;
+      expect(getComputedStyle(removeIcon).display).not.toBe('none');
+      expect(fixture.componentInstance.value).toBe('1');
+
+      removeIcon.click();
+
+      expect(fixture.componentInstance.value).toBe('');
+      expect(getComputedStyle(removeIcon).display).toBe('none');
+    });
   });
 });

--- a/src/clr-addons/searchfield/search-field.ts
+++ b/src/clr-addons/searchfield/search-field.ts
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2018-2022 Porsche Informatik. All Rights Reserved.
+ * Copyright (c) 2018-2023 Porsche Informatik. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Directive, ElementRef, OnDestroy, OnInit, Renderer2, AfterViewInit } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, OnDestroy, OnInit, Optional, Renderer2 } from '@angular/core';
 import { NgControl } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -22,7 +22,7 @@ export class ClrSearchField implements OnInit, OnDestroy, AfterViewInit {
 
   destroyed = new Subject<void>();
 
-  constructor(private renderer: Renderer2, private inputEl: ElementRef, private ngControl: NgControl) {}
+  constructor(private renderer: Renderer2, private inputEl: ElementRef, @Optional() private ngControl: NgControl) {}
 
   ngOnInit(): void {
     this.setHasValueClass(!!this.inputEl.nativeElement.value);


### PR DESCRIPTION
Fix optional ngControl. 

Fixes #1906

Added unit-tests ✅

Also fixed the deprecated `initEvent` when creating input event in tests.

It's a little easier to review without white-space changes: https://github.com/porscheinformatik/clarity-addons/pull/1907/files?w=1