### PR TITLE
Datagrid enum filter: Add custom display name

### DIFF
--- a/src/clr-addons/datagrid/enum-filter/enum-filter.component.html
+++ b/src/clr-addons/datagrid/enum-filter/enum-filter.component.html
@@ -6,11 +6,11 @@
     <input
       type="checkbox"
       clrCheckbox
-      value="{{ possibleValue }}"
+      value="{{ possibleValue.displayValue ?? possibleValue }}"
       name="possibleValue"
-      [ngModel]="filteredValues.includes(possibleValue)"
+      [ngModel]="containsFilterValue(filteredValues, possibleValue)"
       (ngModelChange)="onChange(possibleValue, $event)"
     />
-    <label>{{ possibleValue }}</label>
+    <label>{{ possibleValue.displayValue ?? possibleValue }}</label>
   </clr-checkbox-wrapper>
 </clr-checkbox-container>

--- a/src/clr-addons/datagrid/enum-filter/enum-filter.component.spec.ts
+++ b/src/clr-addons/datagrid/enum-filter/enum-filter.component.spec.ts
@@ -52,6 +52,34 @@ class TestComponentCustomValues {
 
 @Component({
   template: `
+    <clr-datagrid>
+      <clr-dg-column [clrDgField]="'name'">
+        <clr-dg-filter>
+          <clr-enum-filter clrProperty="name" [clrPossibleValues]="customPossibleValues"> </clr-enum-filter>
+        </clr-dg-filter>
+      </clr-dg-column>
+
+      <clr-dg-row *clrDgItems="let data of dataList" [clrDgItem]="data">
+        <clr-dg-cell>{{ data.name }}</clr-dg-cell>
+      </clr-dg-row>
+    </clr-datagrid>
+  `,
+})
+class TestComponentCustomValuesWithDisplayValues {
+  dataList = [{ name: 'TestValue1' }, { name: 'TestValue2' }];
+
+  customPossibleValues = [
+    { value: 'TestValue1', displayValue: 'Test Value 1' },
+    { value: 'TestValue2', displayValue: 'Test Value 2' },
+    { value: 'TestValue3', displayValue: 'Test Value 3' },
+  ];
+
+  @ViewChild(ClrEnumFilterComponent) component: ClrEnumFilterComponent<{ name: string }>;
+  @ViewChild(ClrDatagrid) datagrid: ClrDatagrid;
+}
+
+@Component({
+  template: `
     <body>
       <clr-datagrid>
         <clr-dg-column [clrDgField]="'name'">
@@ -101,7 +129,7 @@ describe('EnumFilterComponent', () => {
       expect(fixture.componentInstance.datagrid.rows.length).toBe(2);
       expect(fixture.componentInstance.component.possibleValues.length).toBe(2);
 
-      fixture.componentInstance.component.onChange('TestValue1', true);
+      fixture.componentInstance.component.onChange({ value: 'TestValue1', displayValue: 'TestValue1' }, true);
       fixture.detectChanges();
 
       expect(fixture.componentInstance.datagrid.rows.length).toBe(1);
@@ -132,7 +160,44 @@ describe('EnumFilterComponent', () => {
       expect(fixture.componentInstance.datagrid.rows.length).toBe(2);
       expect(fixture.componentInstance.component.possibleValues.length).toBe(3);
 
-      fixture.componentInstance.component.onChange('TestValue1', true);
+      fixture.componentInstance.component.onChange({ value: 'TestValue1', displayValue: 'TestValue1' }, true);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.datagrid.rows.length).toBe(1);
+    });
+  });
+
+  describe('custom possible values with display names', () => {
+    let fixture: ComponentFixture<TestComponentCustomValuesWithDisplayValues>;
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ClarityModule, FormsModule],
+        declarations: [TestComponentCustomValuesWithDisplayValues, ClrEnumFilterComponent],
+        providers: [],
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TestComponentCustomValuesWithDisplayValues);
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(fixture.componentInstance.component).toBeTruthy();
+    });
+
+    it('should provide display values', () => {
+      expect(
+        (<{ value: string; displayValue: string }>fixture.componentInstance.component.possibleValues[0]).displayValue
+      ).toBe('Test Value 1');
+    });
+
+    it('filter a value', async () => {
+      expect(fixture.componentInstance.datagrid.rows.length).toBe(2);
+      expect(fixture.componentInstance.component.possibleValues.length).toBe(3);
+
+      fixture.componentInstance.component.onChange({ value: 'TestValue1', displayValue: 'TestValue1' }, true);
       fixture.detectChanges();
 
       expect(fixture.componentInstance.datagrid.rows.length).toBe(1);

--- a/src/dev/src/app/enum-filter/enum-filter.demo.html
+++ b/src/dev/src/app/enum-filter/enum-filter.demo.html
@@ -28,6 +28,25 @@
   </clr-dg-row>
 </clr-datagrid>
 
+<h3>Custom values with dedicated display values</h3>
+<span
+  >For server-driven datasources it might be necessary to define a seperate display name for enums (e.g.
+  internationalization).</span
+>
+<clr-datagrid (clrDgRefresh)="onClrDgRefresh($event)">
+  <clr-dg-column [clrDgField]="'name'"
+    >Name
+    <clr-dg-filter>
+      <clr-enum-filter clrProperty="name" [clrPossibleValues]="customPossibleValuesWithDisplayNames"></clr-enum-filter>
+    </clr-dg-filter>
+  </clr-dg-column>
+
+  <clr-dg-row *clrDgItems="let data of dataList" [clrDgItem]="data">
+    <clr-dg-cell>{{data.name}}</clr-dg-cell>
+  </clr-dg-row>
+</clr-datagrid>
+Current Filters: {{currentFilterDisplayValue}}
+
 <h3>Preselected filter</h3>
 <clr-datagrid>
   <clr-dg-column [clrDgField]="'name'"

--- a/src/dev/src/app/enum-filter/enum-filter.demo.ts
+++ b/src/dev/src/app/enum-filter/enum-filter.demo.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { ClrDatagridStateInterface } from '@clr/angular';
 
 @Component({
   selector: 'clr-enum-filter-demo',
@@ -8,12 +9,22 @@ export class EnumFilterDemo {
   dataList = [{ name: 'TestValue2' }, { name: 'TestValue1' }];
 
   customPossibleValues = ['TestValue2', 'TestValue1', 'TestValue3'];
+  customPossibleValuesWithDisplayNames = [
+    { value: 'v1', displayValue: 'TestValue1' },
+    { value: 'v2', displayValue: 'TestValue2' },
+    { value: 'v3', displayValue: 'TestValue3' },
+  ];
 
   preSelectedValues = ['TestValue2', 'TestValueNotPresent'];
 
   currentFilter = this.preSelectedValues;
+  currentFilterDisplayValue: string[] = [];
 
   filterChanged(value: string[]) {
     this.currentFilter = [...value];
+  }
+
+  onClrDgRefresh(state: ClrDatagridStateInterface) {
+    this.currentFilterDisplayValue = state.filters?.[0]?.value;
   }
 }

--- a/website/src/app/documentation/demos/datagrid/datagrid.demo.html
+++ b/website/src/app/documentation/demos/datagrid/datagrid.demo.html
@@ -66,6 +66,24 @@
     </clr-datagrid>
 
     <clr-code-snippet [clrCode]="enumFilterCustomExample"></clr-code-snippet>
+    <clr-code-snippet [clrCode]="enumFilterCustomExampleTs"></clr-code-snippet>
+
+    <h5>Filter display value differs from enum value</h5>
+    <p>
+      In some cases - mostly using server driven datasources - it might be necessary to define seperate display names
+      for enums (e.g. internationalization). Therefore, it is possible to additionally define custom display values for
+      the filter overlay. The <code class="clr-code">value</code> porperty itself is only provided to the filter state
+      and is therefore present in the state retrieved via the (<code class="clr-code">clrDgRefresh</code>) output of
+      <code class="clr-code">clr-datagrid</code>.
+    </p>
+    <p>
+      From a UX perspective, it is important that the values in the datagrid match the
+      <code class="clr-code">displayValue</code> values (=label in the filter overlay), when providing the display names
+      manually. Generally, overriding the display values should only be used, if the default approach is not sufficient.
+    </p>
+
+    <clr-code-snippet [clrCode]="enumFilterCustomExample"></clr-code-snippet>
+    <clr-code-snippet [clrCode]="enumFilterCustomDisplayNameExampleTs"></clr-code-snippet>
 
     <h4>Preselect filter values</h4>
     <p>

--- a/website/src/app/documentation/demos/datagrid/datagrid.demo.ts
+++ b/website/src/app/documentation/demos/datagrid/datagrid.demo.ts
@@ -112,6 +112,19 @@ const ENUM_FILTER_CUSTOM = `
 </clr-datagrid>
 `;
 
+const ENUM_FILTER_CUSTOM_TS = `
+customPossibleValues = ['TestValue1', 'TestValue2', 'TestValue3', 'TestValue4'];
+`;
+
+const ENUM_FILTER_CUSTOM_DISPLAYNAME_TS = `
+customPossibleValues = [
+  { value: 'ENUM_VALUE_1', displayValue: 'TestValue1' },
+  { value: 'ENUM_VALUE_2', displayValue: 'TestValue2' },
+  { value: 'ENUM_VALUE_3', displayValue: 'TestValue3' },
+  { value: 'ENUM_VALUE_4', displayValue: 'TestValue4' },
+];
+`;
+
 const ENUM_FILTER_PRESELECT = `
 <clr-datagrid>
   <clr-dg-column [clrDgField]="'name'"
@@ -183,6 +196,8 @@ export class DatagridDemo extends ClarityDocComponent {
   persistedStateExample = PERSISTED_STATE;
   enumFilterExample = ENUM_FILTER;
   enumFilterCustomExample = ENUM_FILTER_CUSTOM;
+  enumFilterCustomExampleTs = ENUM_FILTER_CUSTOM_TS;
+  enumFilterCustomDisplayNameExampleTs = ENUM_FILTER_CUSTOM_DISPLAYNAME_TS;
   enumFilterPreselectExample = ENUM_FILTER_PRESELECT;
   dateFilterExample = DATE_FILTER;
   dateFilterPreselectExample = DATE_FILTER_PRESELECT;


### PR DESCRIPTION
We would like to define a "display name" for enums in the `enum-filter` component. The reason is that the name of an enum in the code is often not user friendly. Also, for i18n purposes such a functionality is very useful for us.

Therefore, we extended the `clrPossibleValues` to either accept a list of strings (current master behaviour) or a list of `{ value: string, displayValue: string }` objects.

The demo project was extended to showcase our change:

**Current behaviour**
Enum values are shown as they are defined in code - not very user friendly
![image](https://github.com/porscheinformatik/clarity-addons/assets/38698639/18d09612-d471-4862-a9da-7ff327722dfb)

**Extension to specify a display name**
![image](https://github.com/porscheinformatik/clarity-addons/assets/38698639/1df90f42-4387-4e8e-bb7b-6e5ecc35ecdd)

