### PR TITLE
Fix dropdown overflow using wrong y position in the calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clr-addons",
-  "version": "15.5.7",
+  "version": "15.5.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clr-addons",
-      "version": "15.5.7",
+      "version": "15.5.8",
       "hasInstallScript": true,
       "dependencies": {
         "@angular/animations": "15.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "15.5.7",
+  "version": "15.5.8",
   "private": true,
   "scripts": {
     "build:ui:css": "sass --source-map --precision=8 ./src/clr-addons/themes/phs/phs-theme.scss ./dist/clr-addons/styles/clr-addons-phs.css",

--- a/src/clr-addons/package.json
+++ b/src/clr-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/clr-addons",
-  "version": "15.5.7",
+  "version": "15.5.8",
   "description": "Addon components for Clarity Angular",
   "es2015": "esm2015/clr-addons.js",
   "homepage": "https://porscheinformatik.github.io/clarity-addons/",

--- a/src/dev/src/app/location-bar/location-bar.demo.html
+++ b/src/dev/src/app/location-bar/location-bar.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2018-2022 Porsche Informatik. All Rights Reserved.
+  ~ Copyright (c) 2018-2023 Porsche Informatik. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -10,4 +10,5 @@
   <div><clr-location-bar [clrRoots]="roots2"></clr-location-bar></div>
   <div><clr-location-bar [clrRoots]="rootsLazy"></clr-location-bar></div>
   <div><clr-location-bar [clrRoots]="rootsLongTexts"></clr-location-bar></div>
+  <div><clr-location-bar [clrRoots]="rootsManyItems"></clr-location-bar></div>
 </div>

--- a/src/dev/src/app/location-bar/location-bar.demo.ts
+++ b/src/dev/src/app/location-bar/location-bar.demo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 Porsche Informatik. All Rights Reserved.
+ * Copyright (c) 2018-2023 Porsche Informatik. All Rights Reserved.
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
@@ -16,12 +16,14 @@ export class LocationBarDemo implements OnInit {
   roots2: LocationBarNode<DemoLocationBarNodeId>[];
   rootsLazy: LocationBarNode<DemoLocationBarNodeId>[];
   rootsLongTexts: LocationBarNode<DemoLocationBarNodeId>[];
+  rootsManyItems: LocationBarNode<DemoLocationBarNodeId>[];
 
   ngOnInit() {
     this.buildRoots1();
     this.buildRoots2();
     this.buildRootsLazy();
     this.buildRootsLongTexts();
+    this.buildRootsManyItems();
   }
 
   private buildRoots1() {
@@ -89,5 +91,27 @@ export class LocationBarDemo implements OnInit {
     l1.setChildren([l11, l12]);
 
     this.rootsLongTexts = [l1];
+  }
+
+  private buildRootsManyItems() {
+    const l1 = new LocationBarNode<DemoLocationBarNodeId>(
+      new DemoLocationBarNodeId('long1'),
+      'L1 This one has a LOT of sub-items',
+      false,
+      true
+    );
+
+    const children: LocationBarNode<DemoLocationBarNodeId>[] = [...Array(50).keys()].map(v => {
+      const id = v + 1;
+      return new LocationBarNode<DemoLocationBarNodeId>(
+        new DemoLocationBarNodeId(`id${id}`),
+        `L1.${id} Sub-item ${id}`,
+        true,
+        false
+      );
+    });
+    l1.setChildren(children);
+
+    this.rootsManyItems = [l1];
   }
 }


### PR DESCRIPTION
Clarity sets the dropdown anchor to `position: static` after dropdown is opened once, which means if we open the dropdown a second time, the next `position: relative` parent will be different. This is also a problem because the calculation when using `AfterContentChecked` considers the element to be at "y" of the anchor, not the actual "y" coordinate.

~To be merged after #1973~