### PR TITLE
Datagrid enum filter: Fix persistance

### DIFF
--- a/src/clr-addons/datagrid/enum-filter/enum-filter.component.ts
+++ b/src/clr-addons/datagrid/enum-filter/enum-filter.component.ts
@@ -22,12 +22,11 @@ export class ClrEnumFilterComponent<T extends { [key: string]: any }>
 
   @Input('clrFilterValues')
   public set value(values: string[]) {
-    const converted = values.map(filtered => ({ value: filtered, displayValue: filtered }));
     if (this.possibleValues?.length) {
-      this.filteredValues = converted.filter(filtered => this.possibleValues.includes(filtered));
+      this.filteredValues = this.possibleValues.filter(possibleValue => values?.includes(possibleValue.value));
       this.clrFilterValuesChange.emit(this.getDisplayValues(this.filteredValues));
     } else {
-      this.filteredValues = converted;
+      this.filteredValues = values.map(filtered => ({ value: filtered, displayValue: filtered }));
     }
     this.changes.emit(true);
   }


### PR DESCRIPTION
Applying a persisted filter value was not working if custom display values were used.

Now, we filter the `clrFilterValues` against the `clrPossibleValues` via their `value` property.