### PR TITLE
Persist hidden state independently

### DIFF
--- a/src/clr-addons/datagrid/datagrid-state-persistence/column-hidden-state-persistence.directive.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/column-hidden-state-persistence.directive.ts
@@ -21,7 +21,7 @@ export class ColumnHiddenStatePersistenceDirective implements OnInit, OnDestroy 
 
   ngOnInit() {
     const persistenceEnabled = this.statePersistenceKey?.options?.persistHiddenColumns ?? true;
-    if (this.statePersistenceKey?.options.key && this.columnDirective?.clrDgField && persistenceEnabled) {
+    if (this.statePersistenceKey?.options.key && this.columnDirective?.persistenceKey && persistenceEnabled) {
       /* set hidden states from local storage (if existing) */
       this.initHiddenState();
 
@@ -37,9 +37,9 @@ export class ColumnHiddenStatePersistenceDirective implements OnInit, OnDestroy 
     const persistedGridState = this.readStoredState();
 
     /* read column state if existing */
-    if (persistedGridState?.columns?.[this.columnDirective.clrDgField]) {
+    if (persistedGridState?.columns?.[this.columnDirective.persistenceKey]) {
       /* read column hidden state if existing */
-      const persistedColumnHiddenState = persistedGridState.columns[this.columnDirective.clrDgField].hidden;
+      const persistedColumnHiddenState = persistedGridState.columns[this.columnDirective.persistenceKey].hidden;
       if (persistedColumnHiddenState !== undefined) {
         this.hideableColumnDirective.clrDgHidden = persistedColumnHiddenState === true;
       }
@@ -55,10 +55,10 @@ export class ColumnHiddenStatePersistenceDirective implements OnInit, OnDestroy 
       if (!persistedGridState.columns) {
         persistedGridState.columns = {};
       }
-      let persistedColumnState = persistedGridState.columns[this.columnDirective.clrDgField];
+      let persistedColumnState = persistedGridState.columns[this.columnDirective.persistenceKey];
       if (!persistedColumnState) {
         persistedColumnState = {};
-        persistedGridState.columns[this.columnDirective.clrDgField] = persistedColumnState;
+        persistedGridState.columns[this.columnDirective.persistenceKey] = persistedColumnState;
       }
 
       /* set column hidden state and persist in local storage */

--- a/src/clr-addons/datagrid/datagrid-state-persistence/column-hidden-state-persistence.directive.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/column-hidden-state-persistence.directive.ts
@@ -21,7 +21,7 @@ export class ColumnHiddenStatePersistenceDirective implements OnInit, OnDestroy 
 
   ngOnInit() {
     const persistenceEnabled = this.statePersistenceKey?.options?.persistHiddenColumns ?? true;
-    if (this.statePersistenceKey?.options.key && this.columnDirective?.persistenceKey && persistenceEnabled) {
+    if (this.statePersistenceKey?.options.key && this.columnDirective?.getFieldName() && persistenceEnabled) {
       /* set hidden states from local storage (if existing) */
       this.initHiddenState();
 
@@ -37,9 +37,9 @@ export class ColumnHiddenStatePersistenceDirective implements OnInit, OnDestroy 
     const persistedGridState = this.readStoredState();
 
     /* read column state if existing */
-    if (persistedGridState?.columns?.[this.columnDirective.persistenceKey]) {
+    if (persistedGridState?.columns?.[this.columnDirective.getFieldName()]) {
       /* read column hidden state if existing */
-      const persistedColumnHiddenState = persistedGridState.columns[this.columnDirective.persistenceKey].hidden;
+      const persistedColumnHiddenState = persistedGridState.columns[this.columnDirective.getFieldName()].hidden;
       if (persistedColumnHiddenState !== undefined) {
         this.hideableColumnDirective.clrDgHidden = persistedColumnHiddenState === true;
       }
@@ -55,10 +55,10 @@ export class ColumnHiddenStatePersistenceDirective implements OnInit, OnDestroy 
       if (!persistedGridState.columns) {
         persistedGridState.columns = {};
       }
-      let persistedColumnState = persistedGridState.columns[this.columnDirective.persistenceKey];
+      let persistedColumnState = persistedGridState.columns[this.columnDirective.getFieldName()];
       if (!persistedColumnState) {
         persistedColumnState = {};
-        persistedGridState.columns[this.columnDirective.persistenceKey] = persistedColumnState;
+        persistedGridState.columns[this.columnDirective.getFieldName()] = persistedColumnState;
       }
 
       /* set column hidden state and persist in local storage */

--- a/src/clr-addons/datagrid/datagrid-state-persistence/column-hidden-state-persistence.spec.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/column-hidden-state-persistence.spec.ts
@@ -38,6 +38,9 @@ const PERSISTENCE_KEY = 'ColumnHiddenStatePersistenceDirective';
       <clr-dg-column id="column6" [clrDgField]="'column6'">
         <ng-template clrDgHideableColumn [clrDgHidden]="true"><span>column5</span></ng-template>
       </clr-dg-column>
+      <clr-dg-column id="column7" [clrDgFieldKey]="'column7'">
+        <ng-template clrDgHideableColumn><span>column7</span></ng-template>
+      </clr-dg-column>
     </clr-datagrid>
   `,
 })
@@ -75,11 +78,12 @@ describe('ColumnHiddenStatePersistenceDirective', () => {
     expect(fixture.debugElement.query(By.css('#column3')).nativeElement).not.toHaveClass('datagrid-hidden-column');
     expect(fixture.debugElement.query(By.css('#column4')).nativeElement).not.toHaveClass('datagrid-hidden-column');
     expect(fixture.debugElement.query(By.css('#column5')).nativeElement).toHaveClass('datagrid-hidden-column');
+    expect(fixture.debugElement.query(By.css('#column7')).nativeElement).not.toHaveClass('datagrid-hidden-column');
   });
 
   it('Loaded from storage', () => {
     const storageModel =
-      '{"columns":{"column1": {"hidden":true}, "column2": {"hidden":false}, "column6": {"hidden":false}}}';
+      '{"columns":{"column1": {"hidden":true}, "column2": {"hidden":false}, "column6": {"hidden":false}, "column7": {"hidden":true}}}';
     localStorage.setItem(PERSISTENCE_KEY, storageModel);
 
     fixture.detectChanges();
@@ -90,6 +94,7 @@ describe('ColumnHiddenStatePersistenceDirective', () => {
     expect(fixture.debugElement.query(By.css('#column4')).nativeElement).not.toHaveClass('datagrid-hidden-column');
     expect(fixture.debugElement.query(By.css('#column5')).nativeElement).toHaveClass('datagrid-hidden-column');
     expect(fixture.debugElement.query(By.css('#column6')).nativeElement).not.toHaveClass('datagrid-hidden-column');
+    expect(fixture.debugElement.query(By.css('#column7')).nativeElement).toHaveClass('datagrid-hidden-column');
   });
 
   it('Persisted to storage', () => {
@@ -98,15 +103,19 @@ describe('ColumnHiddenStatePersistenceDirective', () => {
     fixture.componentInstance.hideableColumnDirectives.get(0).clrDgHidden = true;
     fixture.componentInstance.hideableColumnDirectives.get(2).clrDgHidden = true;
     fixture.componentInstance.hideableColumnDirectives.get(3).clrDgHidden = false;
+    fixture.componentInstance.hideableColumnDirectives.get(5).clrDgHidden = true;
 
     expect(fixture.debugElement.query(By.css('#column1')).nativeElement).toHaveClass('datagrid-hidden-column');
     expect(fixture.debugElement.query(By.css('#column2')).nativeElement).not.toHaveClass('datagrid-hidden-column');
     expect(fixture.debugElement.query(By.css('#column3')).nativeElement).toHaveClass('datagrid-hidden-column');
     expect(fixture.debugElement.query(By.css('#column4')).nativeElement).not.toHaveClass('datagrid-hidden-column');
     expect(fixture.debugElement.query(By.css('#column5')).nativeElement).not.toHaveClass('datagrid-hidden-column');
+    expect(fixture.debugElement.query(By.css('#column7')).nativeElement).toHaveClass('datagrid-hidden-column');
 
     const storageModel = localStorage.getItem(PERSISTENCE_KEY);
-    expect(storageModel).toBe('{"columns":{"column1":{"hidden":true},"column5":{"hidden":false}}}');
+    expect(storageModel).toBe(
+      '{"columns":{"column1":{"hidden":true},"column5":{"hidden":false},"column7":{"hidden":true}}}'
+    );
   });
 
   it("doesn't load from storage when 'persistHiddenColumns' is set to false", () => {

--- a/src/clr-addons/datagrid/datagrid-state-persistence/datagrid-field.directive.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/datagrid-field.directive.ts
@@ -9,7 +9,7 @@ export class DatagridFieldDirective {
   @Input()
   clrDgFieldKey: string;
 
-  get persistenceKey(): string {
+  getFieldName(): string {
     return this.clrDgField ?? this.clrDgFieldKey;
   }
 }

--- a/src/clr-addons/datagrid/datagrid-state-persistence/datagrid-field.directive.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/datagrid-field.directive.ts
@@ -1,9 +1,15 @@
 import { Directive, Input } from '@angular/core';
 
 @Directive({
-  selector: '[clrDgField]',
+  selector: '[clrDgField],[clrDgFieldKey]',
 })
 export class DatagridFieldDirective {
   @Input()
   clrDgField: string;
+  @Input()
+  clrDgFieldKey: string;
+
+  get persistenceKey(): string {
+    return this.clrDgField ?? this.clrDgFieldKey;
+  }
 }

--- a/src/dev/src/app/datagrid-state-persistence/datagrid-state-persistence.demo.html
+++ b/src/dev/src/app/datagrid-state-persistence/datagrid-state-persistence.demo.html
@@ -11,6 +11,9 @@
       <clr-dg-column [clrDgField]="'hideableCol'">
         <ng-template clrDgHideableColumn>Hideable String</ng-template>
       </clr-dg-column>
+      <clr-dg-column [clrDgFieldKey]="'hideableCol2'">
+        <ng-template clrDgHideableColumn>Hideable /wo filter</ng-template>
+      </clr-dg-column>
       <clr-dg-column [clrDgField]="'numericCol'" clrDgColType="number">Numeric</clr-dg-column>
       <clr-dg-column [clrDgField]="'dateCol'"
         >Date
@@ -27,6 +30,7 @@
 
       <clr-dg-row *clrDgItems="let item of data$ | async" [clrDgItem]="item">
         <clr-dg-cell>{{item.hideableCol}}</clr-dg-cell>
+        <clr-dg-cell>{{item.hideableCol2}}</clr-dg-cell>
         <clr-dg-cell>{{item.numericCol}}</clr-dg-cell>
         <clr-dg-cell>{{item.dateCol | date}}</clr-dg-cell>
         <clr-dg-cell>{{item.enumCol}}</clr-dg-cell>

--- a/src/dev/src/app/datagrid-state-persistence/datagrid-state-persistence.demo.ts
+++ b/src/dev/src/app/datagrid-state-persistence/datagrid-state-persistence.demo.ts
@@ -13,6 +13,7 @@ export class DatagridStatePersistenceDemo {
   data$ = of(
     [...Array(30).keys()].map(i => ({
       hideableCol: 'item' + i,
+      hideableCol2: 'item' + i,
       numericCol: i,
       dateCol: new Date(),
       enumCol: 'Enum ' + i,

--- a/website/src/app/documentation/demos/datagrid/datagrid.demo.html
+++ b/website/src/app/documentation/demos/datagrid/datagrid.demo.html
@@ -246,8 +246,13 @@
     </clr-alert>
 
     <p>
-      Special requirement for hidden state and current filters: You must use
+      Special requirement for current filters: You must use
       <code class="clr-code">clrDgField</code> directive for columns.
+    </p>
+    <p>
+      Special requirement for hidden state: You must either use
+      <code class="clr-code">clrDgField</code> or <code class="clr-code">clrDgFieldKey</code> (if you don't want filter
+      functionality) directive for columns.
     </p>
     <p>
       Special requirement for sort column and sort order: You must use


### PR DESCRIPTION
Until now, `clrDgField` directive was needed to persist the hidden-state of a column. We would like to extend persisting the hidden-state by defining a persistance key in the directive. This way, one can persist the hidden-state of a column without the need to set `clrDgField`. So `clrDgField` still remains the main source for the persistance key and fallbacks to the implemented extension.

Background is, that we have a couple of columns with calculated values and a server-driven datasource, therefore filtering is not possible on those columns. Still, we want to persist the hidden-state here.

I tried out different approaches and prefered the presented one here as it is slim and non-inversive (as the existing `clrDgHideableColumn` input is simply extended by another property), but I'm open for remarks or alternative ideas. I wanted to wait with extending the documentation until first feedback.

