### PR TITLE
Update clr-warning styles

### DIFF
--- a/src/clr-addons/components.clr-addons.scss
+++ b/src/clr-addons/components.clr-addons.scss
@@ -549,10 +549,8 @@ clr-dropdown-menu .dropdown-header {
   }
 }
 
-.clr-warning {
-  &clr-control-helper {
-    color: $clr-highlight-warning-800;
-  }
+clr-control-helper.clr-warning {
+  color: $clr-highlight-warning-800;
 }
 
 .clr-warning:not(.clr-error):not(.invalid) {
@@ -590,7 +588,6 @@ clr-dropdown-menu .dropdown-header {
 
 .clr-control-warning-icon {
   color: $clr-highlight-warning-800;
-  margin-left: -2px;
   height: 1.2rem;
   width: 1.2rem;
   min-height: 1.2rem;


### PR DESCRIPTION
- Set text color of clr-control-helper when used in combination with *clrIfWarning

- Positioning of warning icon changed.

(cherry picked from commit 3a9426ea75ab3f208757eb671a34fc5f1f57e326)