### PR TITLE
Style prism snippets based on selected theme

### DIFF
--- a/website/angular.json
+++ b/website/angular.json
@@ -30,10 +30,19 @@
                 "glob": "clr-ui-dark.css",
                 "input": "node_modules/@clr/ui/",
                 "output": "/assets/styles"
+              },
+              {
+                "glob": "prism-solarizedlight.css",
+                "input": "node_modules/prismjs/themes",
+                "output": "/assets/styles"
+              },
+              {
+                "glob": "prism-tomorrow.css",
+                "input": "node_modules/prismjs/themes",
+                "output": "/assets/styles"
               }
             ],
             "styles": [
-              "node_modules/prismjs/themes/prism-solarizedlight.css",
               "node_modules/modern-normalize/modern-normalize.css",
               "node_modules/@cds/core/global.min.css",
               "node_modules/@cds/core/styles/theme.dark.min.css",

--- a/website/src/app/app.component.ts
+++ b/website/src/app/app.component.ts
@@ -12,6 +12,12 @@ declare let ga: Function;
 
 const PRODUCT_TITLE = require('../settings/global.json').alt_title;
 
+const PRISM_THEMES_PER_CDS_THEME = new Map([
+  ['phs', 'solarizedlight'],
+  ['light', 'solarizedlight'],
+  ['dark', 'tomorrow'],
+]);
+
 @Component({
   selector: 'root',
   templateUrl: './app.component.html',
@@ -101,7 +107,9 @@ export class AppComponent implements OnInit {
     return returnArray;
   }
 
-  setTheme(theme: { cdsTheme: string; href: string }): void {
+  setTheme(theme: { cdsTheme: string; name: string }): void {
     this.document.body.setAttribute('cds-theme', theme.cdsTheme);
+    const newTheme = PRISM_THEMES_PER_CDS_THEME.get(theme.cdsTheme) ?? 'solarizedlight';
+    this.document.querySelector('#prism-theme-style')?.setAttribute('href', `/assets/styles/prism-${newTheme}.css`);
   }
 }

--- a/website/src/app/documentation/get-started/get-started.component.html
+++ b/website/src/app/documentation/get-started/get-started.component.html
@@ -21,7 +21,7 @@
     ></clr-code-snippet>
   </p>
 
-  <h5 id="styles">Step 2: Adding customized styles</h5>
+  <h4 id="styles">Step 2: Adding customized styles</h4>
   <p>
     You can find the component styles and PHS theme in
     <code class="clr-code">node_modules/&#64;porscheinformatik/clr-addons/styles/</code>.
@@ -48,7 +48,7 @@
     <clr-code-snippet clrLanguage="html" [clrCode]="phsTheme"></clr-code-snippet>
   </p>
 
-  <h5 id="angular">Step 3: Add Clarity-Addons to Angular application</h5>
+  <h4 id="angular">Step 3: Add Clarity-Addons to Angular application</h4>
   <p>
     Import the ClarityAddonsModule into your Angular application's module. Your application's main module might look
     like this:
@@ -73,9 +73,9 @@
   </p>
   <p>
     Internal Porsche Informatik Guidelines can be found here:
-    <a href="https://confluence.porscheinformatik.com/confluence/display/COPUI/Contribution+to+Clarity-Addons"
-      >Porsche Informatik Guidelines</a
-    >
+    <a href="https://confluence.porscheinformatik.com/confluence/display/COPUI/Contribution+to+Clarity-Addons">
+      Porsche Informatik Guidelines
+    </a>
   </p>
   <div style="visibility: hidden; height: 80vh">This is a spacer to force sidenav highlighting on scroll</div>
 </section>

--- a/website/src/app/utils/code-snippet.ts
+++ b/website/src/app/utils/code-snippet.ts
@@ -16,14 +16,6 @@ import { CodeHighlight } from './code-highlight';
       <pre><code class="clr-code">{{code.trim()}}</code></pre>
     </ng-container>
   `,
-  styles: [
-    `
-      pre {
-        background: transparent;
-        padding: 12px;
-      }
-    `,
-  ],
 })
 export class CodeSnippet implements AfterViewInit {
   @ViewChild(CodeHighlight) codeHighlight: CodeHighlight;

--- a/website/src/index.html
+++ b/website/src/index.html
@@ -14,6 +14,7 @@
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="icon" href="favicon.ico?v=2" type="image/x-icon" />
+    <link id="prism-theme-style" rel="stylesheet" href="/assets/styles/prism-solarizedlight.css" />
   </head>
 
   <body id="body" cds-theme="phs">

--- a/website/src/styles/code.scss
+++ b/website/src/styles/code.scss
@@ -49,8 +49,7 @@
 :not(pre) > code[class*='language-'],
 pre[class*='language-'],
 pre {
-  background: transparent;
-  padding: 0 0 $bl-1_0 $bl-1_0;
+  background: var(--clr-forms-textarea-background-color);
 }
 
 // Fixes specific prism issue only for labels with badges (#1700: https://github.com/vmware/clarity/issues/1700)

--- a/website/src/styles/components.scss
+++ b/website/src/styles/components.scss
@@ -210,9 +210,7 @@ table.buttons-cmp-table td {
     height: 100%;
 
     .dox-content-wrapper {
-      padding-left: $bl-1_5;
-      padding-top: $bl-0_25;
-      padding-bottom: $bl-4_0;
+      padding: $bl-0_25 $bl-1_5 $bl-4_0;
       max-width: 1200px;
       width: 100%;
     }
@@ -250,10 +248,10 @@ table.buttons-cmp-table td {
     }
 
     a.active {
-      color: #000;
+      color: var(--clr-link-active-color);
 
       &:hover {
-        color: #000;
+        color: var(--clr-link-hover-color);
       }
     }
   }

--- a/website/src/styles/global.scss
+++ b/website/src/styles/global.scss
@@ -75,16 +75,6 @@ h6.indent + p.indent {
   }
 }
 
-//Overriding PrismJS styles. This is in code.scss and not in code.clarity.scss because
-//we don't want to override the background in case someone chooses to use
-//another PrismJS theme.
-:not(pre) > code[class*='language-'],
-pre[class*='language-'],
-pre,
-code[class*='language-'] {
-  background: transparent;
-}
-
 @media (max-width: 991px) {
   .layout-components {
     .content-area > section {
@@ -174,7 +164,6 @@ a.btn-primary {
   }
 
   h5 {
-    color: #000;
     margin-top: 1rem;
   }
 
@@ -199,12 +188,6 @@ a.btn-primary {
 
   h6 + p {
     margin-top: $bl-0_25;
-  }
-
-  pre {
-    // TODO: move this into the background style of the code-highlight
-    // component...
-    background: #fff !important;
   }
 }
 


### PR DESCRIPTION
this is just the website part of #2256, to change the rows etc I'll make a follow-up, as we'll need a version increase (and the status row classes are also broken in dark mode)

---

snippets before
![image](https://github.com/user-attachments/assets/e0d1e3d8-c2f8-47db-80bd-67bccee12c98)

snippets after
![image](https://github.com/user-attachments/assets/ac5992f9-b529-4f85-8f2c-444b54653816)
