### PR TITLE
Disable pointer events when datagrid-no-select-all has been added

### DIFF
--- a/src/clr-addons/components.clr-addons.scss
+++ b/src/clr-addons/components.clr-addons.scss
@@ -188,8 +188,12 @@ body,
   }
 }
 
-.datagrid-no-select-all .datagrid-header .datagrid-select .clr-checkbox-wrapper {
-  display: none;
+.datagrid-no-select-all .datagrid-header .datagrid-select {
+  pointer-events: none;
+
+  .clr-checkbox-wrapper {
+    display: none;
+  }
 }
 
 .datagrid-full-height {


### PR DESCRIPTION
This change disables pointer events in case datagrid-no-select-all has been added. Otherwise the checkbox is not visible but clickable anyway.