### PR TITLE
Fix datagrid sticky row transparent background

### DIFF
--- a/src/clr-addons/components.clr-addons.scss
+++ b/src/clr-addons/components.clr-addons.scss
@@ -414,7 +414,15 @@ clr-date-container .clr-control-container {
   background-color: inherit !important;
 }
 
-.datagrid-row-sticky,
+.datagrid-highlight-error,
+.datagrid-highlight-warning,
+.datagrid-highlight-info,
+.datagrid-highlight-success {
+  .datagrid-row-sticky {
+    background-color: inherit !important;
+  }
+}
+
 clr-expandable-animation {
   background-color: inherit !important;
 }

--- a/website/src/app/documentation/demos/datagrid/datagrid.demo.html
+++ b/website/src/app/documentation/demos/datagrid/datagrid.demo.html
@@ -397,6 +397,13 @@
         >
       </clr-dg-row>
 
+      <clr-dg-detail *clrIfDetail="let detail">
+        <clr-dg-detail-header>Datagrid detail</clr-dg-detail-header>
+        <clr-dg-detail-body>
+          <span>Datagrid detail text</span>
+        </clr-dg-detail-body>
+      </clr-dg-detail>
+
       <clr-dg-footer>
         <clr-dg-pagination [clrDgPageSize]="10">
           <clr-dg-page-size [clrPageSizeOptions]="[5,10,15,50,100]">Entries per page</clr-dg-page-size>


### PR DESCRIPTION
Because of the dg row highlighting the background-color was set to `inherit`. But that leads to seeing the row content through the sticky row if there is no highlighting applied. This fix should reset the background-color only for the highlighted rows.
PS: REQ is not even ordered yet, will release this when needed.

before:
![image](https://github.com/user-attachments/assets/65012b9a-32aa-46be-882e-6d704e6326aa)

after:
![image](https://github.com/user-attachments/assets/cb8b2b1b-a6a6-44e5-a8cc-bac2e379529c)
