### PR TITLE
Make Clarity dependencies more relaxed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clr-addons",
-  "version": "18.1.5",
+  "version": "18.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clr-addons",
-      "version": "18.1.5",
+      "version": "18.1.6",
       "dependencies": {
         "@angular/animations": "18.2.5",
         "@angular/cdk": "18.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "18.1.5",
+  "version": "18.1.6",
   "private": true,
   "scripts": {
     "build:ui:css": "sass --source-map --precision=8 ./src/clr-addons/themes/phs/phs-theme.scss ./dist/clr-addons/styles/clr-addons-phs.css",

--- a/replace-versions.js
+++ b/replace-versions.js
@@ -13,16 +13,16 @@ readFile('./package.json', 'utf-8', (err, data) => {
   const packageJson = JSON.parse(data);
   const addonsVersion = packageJson.version;
   let angularVersion = packageJson.dependencies['@angular/core'];
-  const clarityVersion = packageJson.dependencies['@clr/angular'];
-  const cdsCoreVersion = packageJson.dependencies['@cds/core'];
+  let clarityVersion = packageJson.dependencies['@clr/angular'];
+  let cdsCoreVersion = packageJson.dependencies['@cds/core'];
 
   if (angularVersion.indexOf('.') > 0) {
     angularVersion = angularVersion.substring(0, angularVersion.indexOf('.')) + '.0.0';
   }
 
-  if (!angularVersion.startsWith('^')) {
-    angularVersion = '^' + angularVersion;
-  }
+  angularVersion = prependCaretIfMissing(angularVersion);
+  clarityVersion = prependCaretIfMissing(clarityVersion);
+  cdsCoreVersion = prependCaretIfMissing(cdsCoreVersion);
 
   const envFile = './src/clr-addons/package.json';
   readFile(envFile, 'utf-8', (err, data) => {
@@ -34,3 +34,7 @@ readFile('./package.json', 'utf-8', (err, data) => {
     writeFile(envFile, data, 'utf-8', handleError);
   });
 });
+
+function prependCaretIfMissing(version) {
+  return version.startsWith('^') ? version : '^' + version;
+}

--- a/src/clr-addons/package.json
+++ b/src/clr-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/clr-addons",
-  "version": "18.1.5",
+  "version": "18.1.6",
   "description": "Addon components for Clarity Angular",
   "es2015": "esm2015/clr-addons.js",
   "homepage": "https://porscheinformatik.github.io/clarity-addons/",
@@ -21,9 +21,9 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@angular/compiler": "^18.0.0",
-    "@clr/angular": "17.4.0",
-    "@cds/core": "6.14.0",
-    "@clr/ui": "17.4.0"
+    "@clr/angular": "^17.4.0",
+    "@cds/core": "^6.14.0",
+    "@clr/ui": "^17.4.0"
   },
   "author": "porscheinformatik",
   "license": "MIT",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -52,7 +52,7 @@
     },
     "../dist/clr-addons": {
       "name": "@porscheinformatik/clr-addons",
-      "version": "18.1.5",
+      "version": "18.1.6",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -61,9 +61,9 @@
         "@angular/common": "^18.0.0",
         "@angular/compiler": "^18.0.0",
         "@angular/core": "^18.0.0",
-        "@cds/core": "6.14.0",
-        "@clr/angular": "17.3.1",
-        "@clr/ui": "17.3.1"
+        "@cds/core": "^6.14.0",
+        "@clr/angular": "^17.4.0",
+        "@clr/ui": "^17.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
+ update replace-versions.js script to do it automatically for Clarity versions too (not just Angular)
+ bump version to 18.1.6