### PR TITLE
Add persistence for datagrid column width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clr-addons",
-  "version": "18.1.10",
+  "version": "18.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clr-addons",
-      "version": "18.1.10",
+      "version": "18.2.0",
       "dependencies": {
         "@angular/animations": "18.2.5",
         "@angular/cdk": "18.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "18.1.10",
+  "version": "18.2.0",
   "private": true,
   "scripts": {
     "build:ui:css": "sass --source-map --precision=8 ./src/clr-addons/themes/phs/phs-theme.scss ./dist/clr-addons/styles/clr-addons-phs.css",

--- a/src/clr-addons/datagrid/datagrid-state-persistence/datagrid-state-persistence-model.interface.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/datagrid-state-persistence-model.interface.ts
@@ -9,4 +9,5 @@ export interface ClrDatagridStatePersistenceModel {
 export interface ClrColumnStatePersistenceModel {
   hidden?: boolean;
   filterValue?: any;
+  width?: string;
 }

--- a/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-options.interface.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-options.interface.ts
@@ -5,4 +5,5 @@ export interface StatePersistenceOptions {
   persistPagination?: boolean;
   persistSort?: boolean;
   persistHiddenColumns?: boolean;
+  persistColumnWidths?: boolean;
 }

--- a/src/clr-addons/package.json
+++ b/src/clr-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/clr-addons",
-  "version": "18.1.10",
+  "version": "18.2.0",
   "description": "Addon components for Clarity Angular",
   "es2015": "esm2015/clr-addons.js",
   "homepage": "https://porscheinformatik.github.io/clarity-addons/",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -52,7 +52,7 @@
     },
     "../dist/clr-addons": {
       "name": "@porscheinformatik/clr-addons",
-      "version": "18.1.10",
+      "version": "18.2.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/website/src/app/documentation/demos/datagrid/datagrid.demo.html
+++ b/website/src/app/documentation/demos/datagrid/datagrid.demo.html
@@ -301,6 +301,7 @@
       <li>Page size (LocalStorage)</li>
       <li>Current page (SessionStorage)</li>
       <li>Current filter values (SessionStorage)</li>
+      <li>Column width (LocalStorage)</li>
     </ul>
 
     <p>
@@ -350,7 +351,7 @@
     </ul>
     <p>
       To turn off the persistence for specific parts of the datagrid, the
-      <code class="clr-code">[clrStatePersistenceKey]</code> offers several optional properties. All of these are
+      <code class="clr-code">[clrStatePersistenceKey]</code> offers several optional properties. The following ones are
       opt-out properties and will default to <code class="clr-code">true</code> when not specified.
     </p>
     <br />
@@ -360,6 +361,10 @@
       <li>persistSort: When set to false, sort column and sort order will not be persisted</li>
       <li>persistHiddenColumns: When set to false, state of each column, hidden or visible, will not be persisted</li>
     </ul>
+    <p>
+      Last but not least, you can specify the "persistColumnWidths" property, in order to store the width of each
+      column. This is an opt-in behavior, and will default to <code class="clr-code">false</code> when not specified.
+    </p>
 
     <br />
     <p>


### PR DESCRIPTION
Same as other flags for datagrid persistence - but opt-in (as it's not that common of a use-case)

Saving is done in `OnDestroy`, because I couldn't find an appropriate output in Clarity code to hook into (and `ColumnsService` is not exported from Clarity 😞). The beforeunload is needed, because ondestroy will not trigger if the window is closed or window is refreshed.