### PR TITLE
[C3DEV-317064](C3DEV-319667) Not more than 2 history entries are shown in Service

### DIFF
--- a/src/clr-addons/history/history.service.ts
+++ b/src/clr-addons/history/history.service.ts
@@ -96,13 +96,6 @@ export class ClrHistoryService {
       this.setCookie(this.cookieName, this.encode([]), domain);
     } else {
       entries = this.reduceSize(entries);
-      // encode title & pagename to be cookie saving save
-      if (entries && entries.length > 0) {
-        entries.forEach(entry => {
-          entry.title = encodeURI(entry.title);
-          entry.pageName = encodeURI(entry.pageName);
-        });
-      }
       this.setCookie(this.cookieName, this.encode(entries), domain);
     }
   }
@@ -200,7 +193,7 @@ export class ClrHistoryService {
   }
 
   private encode(content: ClrHistoryModel[]): string {
-    const jsonString = btoa(encodeURIComponent(JSON.stringify(content)));
+    const jsonString = btoa(JSON.stringify(content));
     return jsonString.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '!');
   }
 


### PR DESCRIPTION
[C3DEV-317064](C3DEV-319667) Not more than 2 history entries are shown in Service (Es werden nicht mehr als 2 Historieneinträge im Service angezeigt) - C3REQPHSRE-4604

This reduces the Cookie length by about 33.25% on average and thus leads to the case with only 2 entries being shown happening less frequently.

Similiar Change will be contributed to cross-core-tapestry on gitlab too.

