### PR TITLE
Fix view edit section collapse animation playing on init

### DIFF
--- a/src/clr-addons/view-edit-section/view-edit-section.html
+++ b/src/clr-addons/view-edit-section/view-edit-section.html
@@ -24,7 +24,7 @@
         </div>
       </div>
     </div>
-    <div class="card-text" [@collapseExpandAnimation] *ngIf="!(_isCollapsed && _isCollapsible)">
+    <div class="card-text" [@collapseExpandAnimation]="initialized" *ngIf="!(_isCollapsed && _isCollapsible)">
       <ng-template [ngTemplateOutlet]="viewRef" *ngIf="!editMode"></ng-template>
       <ng-template [ngTemplateOutlet]="editRef" *ngIf="editMode"></ng-template>
       <ng-container *ngIf="editMode">

--- a/src/clr-addons/view-edit-section/view-edit-section.ts
+++ b/src/clr-addons/view-edit-section/view-edit-section.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { angleIcon, ClarityIcons, pencilIcon } from '@cds/core/icon';
 
@@ -33,7 +33,7 @@ ClarityIcons.addIcons(angleIcon, pencilIcon);
   ],
   standalone: false,
 })
-export class ClrViewEditSection {
+export class ClrViewEditSection implements AfterViewInit {
   @Input('clrTitle') _title: string;
   @Input('clrSaveText') _saveText = 'Save';
   @Input('clrPreventModeChangeOnSave') _preventSave = false;
@@ -65,6 +65,11 @@ export class ClrViewEditSection {
   }
 
   private _editMode = false;
+  initialized = false;
+
+  ngAfterViewInit() {
+    this.initialized = true;
+  }
 
   public onSubmit(): void {
     this._submitted.emit();

--- a/src/dev/src/app/view-edit-section/view-edit-section.demo.html
+++ b/src/dev/src/app/view-edit-section/view-edit-section.demo.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2018-2023 Porsche Informatik. All Rights Reserved.
+  ~ Copyright (c) 2018-2025 Porsche Informatik. All Rights Reserved.
   ~ This software is released under MIT license.
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
@@ -169,6 +169,28 @@
     <div class="clr-col-12">
       <clr-view-edit-section clrTitle="Not Editable" [clrEditable]="false" [clrViewRef]="viewBlock4">
         <ng-template #viewBlock4>
+          <form clrForm clrLayout="horizontal">
+            <div class="clr-form-control clr-row">
+              <label class="clr-col-md-2 clr-control-label">Hobby</label>
+              <span class="text-truncate clr-col-md-10">Computer</span>
+            </div>
+            <div class="clr-form-control clr-row">
+              <label class="clr-col-md-2 clr-control-label">Driving licence number</label>
+              <span class="text-truncate clr-col-md-10">12345</span>
+            </div>
+          </form>
+        </ng-template>
+      </clr-view-edit-section>
+    </div>
+
+    <div class="clr-col-12">
+      <clr-view-edit-section
+        clrTitle="Collapsible"
+        [clrEditable]="false"
+        [clrViewRef]="viewBlock5"
+        [clrIsCollapsible]="true"
+      >
+        <ng-template #viewBlock5>
           <form clrForm clrLayout="horizontal">
             <div class="clr-form-control clr-row">
               <label class="clr-col-md-2 clr-control-label">Hobby</label>


### PR DESCRIPTION
Previously, the view edit section always played a expand animation in first render. 

This is very visually distracting and not desired. 

This commit disables the animation on init while keeping the animation on user interaction (collapse/expand)