### PR TITLE
Add "clr-combobox-vertical" CSS class for comboboxes with long items

### DIFF
--- a/src/clr-addons/themes/phs/_css.overrides.scss
+++ b/src/clr-addons/themes/phs/_css.overrides.scss
@@ -245,6 +245,11 @@
     width: 100%;
   }
 
+  .clr-combobox-vertical .clr-combobox-wrapper {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
   .clr-form-horizontal .clr-form-control {
     align-items: baseline;
   }

--- a/src/clr-addons/themes/phs/_css.overrides.scss
+++ b/src/clr-addons/themes/phs/_css.overrides.scss
@@ -248,6 +248,22 @@
   .clr-combobox-vertical .clr-combobox-wrapper {
     align-items: flex-start;
     flex-direction: column;
+
+    // so that the long items do not overlap the dropdown button (normally there is the input on the right)
+    span[role='grid'] {
+      max-width: 100%;
+
+      span[role='row'].label-combobox-pill {
+        max-width: 100%;
+
+        span[role='gridcell'] {
+          // Clarity does not export a token for the "row gap" in the combobox item, so I have to use a hardcoded value
+          max-width: calc(100% - var(--clr-combobox-caret-icon-size) - var(--cds-global-space-3));
+          text-overflow: ellipsis;
+          overflow: hidden;
+        }
+      }
+    }
   }
 
   .clr-form-horizontal .clr-form-control {

--- a/src/dev/src/app/readonly/readonly.demo.html
+++ b/src/dev/src/app/readonly/readonly.demo.html
@@ -300,7 +300,7 @@
     <div class="clr-col-6">
       <clr-combobox-container>
         <label>ComboBox MultiSelect</label>
-        <clr-combobox [(ngModel)]="selection" name="multiSelect" clrMulti="true">
+        <clr-combobox [(ngModel)]="selection" name="multiSelect" clrMulti="true" class="clr-combobox-vertical">
           <ng-container *clrOptionSelected="let selected"> {{ selected?.name }}</ng-container>
           <clr-options>
             <clr-option *clrOptionItems="let state of states; field: 'name'" [clrValue]="state">

--- a/src/dev/src/app/readonly/readonly.demo.ts
+++ b/src/dev/src/app/readonly/readonly.demo.ts
@@ -30,27 +30,8 @@ export class ReadonlyDemo {
   numericValue = 1234456456;
 
   states = states;
-  selection: State[] = [
-    {
-      name: 'Alabama',
-      abbreviation: 'AL',
-    },
-    {
-      name: 'Alaska',
-      abbreviation: 'AK',
-    },
-  ];
-
-  selectionReadOnly: State[] = [
-    {
-      name: 'Alabama',
-      abbreviation: 'AL',
-    },
-    {
-      name: 'Alaska',
-      abbreviation: 'AK',
-    },
-  ];
+  selection: State[] = [states[0], states[1]];
+  selectionReadOnly: State[] = [states[0], states[1]];
 
   date = new Date().toLocaleDateString('de-DE');
   time = '11:00';
@@ -69,5 +50,21 @@ export const states: State[] = [
   {
     name: 'Alaska',
     abbreviation: 'AK',
+  },
+  {
+    name: 'Arizona',
+    abbreviation: 'AZ',
+  },
+  {
+    name: 'Arkansas',
+    abbreviation: 'Ar',
+  },
+  {
+    name: 'California',
+    abbreviation: 'CA',
+  },
+  {
+    name: 'Colorado',
+    abbreviation: 'CO',
   },
 ];


### PR DESCRIPTION
The selected items wrapper and the text input of the combobox are by default displayed as two columns side by side. This looks really weird when the items are long. With the new `clr-combobox-vertical` class they are displayed on top of one another.

default styling
![image](https://github.com/user-attachments/assets/b27a3e42-359c-49cd-83e7-5f8b4ecafd53)

with optional class
![image](https://github.com/user-attachments/assets/822e1a3c-6be9-4ee3-832d-68e31ac7ca78)
