### PR TITLE
Fix a case where persisted filters don't apply when the "property" field is an input signal (backport to v18)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clr-addons",
-  "version": "18.2.8",
+  "version": "18.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clr-addons",
-      "version": "18.2.8",
+      "version": "18.2.9",
       "dependencies": {
         "@angular/animations": "18.2.5",
         "@angular/cdk": "18.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "18.2.8",
+  "version": "18.2.9",
   "private": true,
   "scripts": {
     "build:ui:css": "sass --source-map --precision=8 ./src/clr-addons/themes/phs/phs-theme.scss ./dist/clr-addons/styles/clr-addons-phs.css",

--- a/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.directive.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.directive.ts
@@ -6,8 +6,10 @@ import {
   ElementRef,
   HostListener,
   Input,
+  isSignal,
   OnDestroy,
   QueryList,
+  Signal,
 } from '@angular/core';
 import {
   ClrDatagrid,
@@ -356,7 +358,12 @@ export class StatePersistenceKeyDirective implements AfterContentInit, OnDestroy
   private getFilterPropertyName(filter: ClrDatagridFilterInterface<unknown, unknown>): string {
     // for NestedProperty we need to get the original property
     const filterWithProp = filter as unknown as { property: unknown };
-    return ((filterWithProp.property as Record<string, unknown>)?.prop || filterWithProp.property) as string;
+    return ((filterWithProp.property as Record<string, unknown>)?.prop ||
+      this.resolveSignal(filterWithProp.property)) as string;
+  }
+
+  private resolveSignal<T>(value: T | Signal<T>): T {
+    return isSignal(value) ? value() : value;
   }
 
   private getSortProperty(sortBy: ClrDatagridComparatorInterface<unknown> | string): string | undefined {

--- a/src/clr-addons/package.json
+++ b/src/clr-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/clr-addons",
-  "version": "18.2.8",
+  "version": "18.2.9",
   "description": "Addon components for Clarity Angular",
   "es2015": "esm2015/clr-addons.js",
   "homepage": "https://porscheinformatik.github.io/clarity-addons/",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -52,7 +52,7 @@
     },
     "../dist/clr-addons": {
       "name": "@porscheinformatik/clr-addons",
-      "version": "18.2.8",
+      "version": "18.2.9",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"


### PR DESCRIPTION
(cherry picked from commit 37767847b2c7f57406856be212cbc2bcd0dd8632)