### PR TITLE
Fix state persistence for server driven datagrids

### DIFF
--- a/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.directive.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.directive.ts
@@ -24,7 +24,7 @@ import {
 } from '@clr/angular';
 import { ClrDatagridStatePersistenceModel } from './datagrid-state-persistence-model.interface';
 import { delay, Subject } from 'rxjs';
-import { take, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 import { StatePersistenceOptions } from './state-persistence-options.interface';
 
 const DATE_TYPE = 'date';
@@ -135,7 +135,7 @@ export class StatePersistenceKeyDirective implements AfterContentInit, OnDestroy
   private initCurrentPage(savedState: ClrDatagridStatePersistenceModel) {
     /* init current page of datagrid if already persisted */
     if (savedState?.currentPage) {
-      this.datagrid.items.change.pipe(take(1)).subscribe(() => (this.pagination.page.current = savedState.currentPage));
+      this.pagination.page.current = savedState.currentPage;
     }
   }
 

--- a/src/clr-addons/datagrid/enum-filter/enum-filter.component.ts
+++ b/src/clr-addons/datagrid/enum-filter/enum-filter.component.ts
@@ -80,16 +80,12 @@ export class ClrEnumFilterComponent<T extends { [key: string]: any }>
   }
 
   setPossibleValues(values: (string | FilterValue)[]) {
-    if (values === null) {
-      values = [];
-    }
+    values ??= [];
     this.possibleValues = values.map(value => this.mapValue(value));
     this.possibleValues.sort((v1, v2) => v1.displayValue.localeCompare(v2.displayValue));
     this.filteredValues = this.filteredValues.filter(filtered =>
       this.containsFilterValue(this.possibleValues, filtered)
     );
-
-    this.emitFilterChanged();
   }
 
   onChange(selectedValue: FilterValue, checkboxState: boolean) {

--- a/src/dev/src/app/datagrid-state-persistence/datagrid-state-persistence.demo.html
+++ b/src/dev/src/app/datagrid-state-persistence/datagrid-state-persistence.demo.html
@@ -1,46 +1,82 @@
-<div [ngStyle]="{display: 'flex', 'flex-direction': 'column', height: 'calc(100% - 30px)'}">
-  <h2>Datagrid state persistence</h2>
+<h2>Datagrid state persistence</h2>
 
-  <div [ngStyle]="{'min-height': 0}">
-    <clr-datagrid
-      class="datagrid-full-height"
-      (clrDgRefresh)="refresh($event)"
-      [clrStatePersistenceKey]="{key:'datagrid.demo.statePersistence', serverDriven: true}"
-      [clrPaginationDescription]="'{{first}} - {{last}} of {{total}} entries'"
-    >
-      <clr-dg-column [clrDgField]="'hideableCol'">
-        <ng-template clrDgHideableColumn>Hideable String</ng-template>
-      </clr-dg-column>
-      <clr-dg-column [clrDgFieldKey]="'hideableCol2'">
-        <ng-template clrDgHideableColumn>Hideable /wo filter</ng-template>
-      </clr-dg-column>
-      <clr-dg-column [clrDgField]="'numericCol'" clrDgColType="number">Numeric</clr-dg-column>
-      <clr-dg-column [clrDgField]="'dateCol'"
-        >Date
-        <clr-dg-filter>
-          <clr-date-filter clrProperty="dateCol"></clr-date-filter>
-        </clr-dg-filter>
-      </clr-dg-column>
-      <clr-dg-column [clrDgField]="'enumCol'">
-        Enum
-        <clr-dg-filter>
-          <clr-enum-filter clrProperty="enumCol"></clr-enum-filter>
-        </clr-dg-filter>
-      </clr-dg-column>
+<h3>Backend Filtering</h3>
+<clr-datagrid
+  (clrDgRefresh)="refresh($event)"
+  [clrStatePersistenceKey]="{key:'datagrid.demo.statePersistence', serverDriven: true}"
+  [clrPaginationDescription]="'{{first}} - {{last}} of {{total}} entries'"
+>
+  <clr-dg-column [clrDgField]="'hideableCol'">
+    <ng-template clrDgHideableColumn>Hideable String</ng-template>
+  </clr-dg-column>
+  <clr-dg-column [clrDgFieldKey]="'hideableCol2'">
+    <ng-template clrDgHideableColumn>Hideable /wo filter</ng-template>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'numericCol'" clrDgColType="number">Numeric</clr-dg-column>
+  <clr-dg-column [clrDgField]="'dateCol'"
+    >Date
+    <clr-dg-filter>
+      <clr-date-filter clrProperty="dateCol"></clr-date-filter>
+    </clr-dg-filter>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'enumCol'">
+    Enum
+    <clr-dg-filter>
+      <clr-enum-filter clrProperty="enumCol"></clr-enum-filter>
+    </clr-dg-filter>
+  </clr-dg-column>
 
-      <clr-dg-row *clrDgItems="let item of data$ | async" [clrDgItem]="item">
-        <clr-dg-cell>{{item.hideableCol}}</clr-dg-cell>
-        <clr-dg-cell>{{item.hideableCol2}}</clr-dg-cell>
-        <clr-dg-cell>{{item.numericCol}}</clr-dg-cell>
-        <clr-dg-cell>{{item.dateCol | date}}</clr-dg-cell>
-        <clr-dg-cell>{{item.enumCol}}</clr-dg-cell>
-      </clr-dg-row>
+  <clr-dg-row *ngFor="let item of data$ | async" [clrDgItem]="item">
+    <clr-dg-cell>{{ item.hideableCol }}</clr-dg-cell>
+    <clr-dg-cell>{{ item.hideableCol2 }}</clr-dg-cell>
+    <clr-dg-cell>{{ item.numericCol }}</clr-dg-cell>
+    <clr-dg-cell>{{ item.dateCol | date }}</clr-dg-cell>
+    <clr-dg-cell>{{ item.enumCol }}</clr-dg-cell>
+  </clr-dg-row>
 
-      <clr-dg-footer>
-        <clr-dg-pagination [clrDgTotalItems]="total" [clrDgPageSize]="15">
-          <clr-dg-page-size [clrPageSizeOptions]="[10,15,20,50,100]">Entries per page</clr-dg-page-size>
-        </clr-dg-pagination>
-      </clr-dg-footer>
-    </clr-datagrid>
-  </div>
-</div>
+  <clr-dg-footer>
+    <clr-dg-pagination [clrDgTotalItems]="total" [clrDgPageSize]="15">
+      <clr-dg-page-size [clrPageSizeOptions]="[10,15,20,50,100]">Entries per page</clr-dg-page-size>
+    </clr-dg-pagination>
+  </clr-dg-footer>
+</clr-datagrid>
+
+<h3>Frontend Filtering</h3>
+<clr-datagrid
+  [clrStatePersistenceKey]="{key:'datagrid.demo.statePersistence.frontend', serverDriven: true}"
+  [clrPaginationDescription]="'{{first}} - {{last}} of {{total}} entries'"
+>
+  <clr-dg-column [clrDgField]="'hideableCol'">
+    <ng-template clrDgHideableColumn>Hideable String</ng-template>
+  </clr-dg-column>
+  <clr-dg-column [clrDgFieldKey]="'hideableCol2'">
+    <ng-template clrDgHideableColumn>Hideable /wo filter</ng-template>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'numericCol'" clrDgColType="number">Numeric</clr-dg-column>
+  <clr-dg-column [clrDgField]="'dateCol'"
+    >Date
+    <clr-dg-filter>
+      <clr-date-filter clrProperty="dateCol"></clr-date-filter>
+    </clr-dg-filter>
+  </clr-dg-column>
+  <clr-dg-column [clrDgField]="'enumCol'">
+    Enum
+    <clr-dg-filter>
+      <clr-enum-filter clrProperty="enumCol"></clr-enum-filter>
+    </clr-dg-filter>
+  </clr-dg-column>
+
+  <clr-dg-row *clrDgItems="let item of frontendData$ | async" [clrDgItem]="item">
+    <clr-dg-cell>{{ item.hideableCol }}</clr-dg-cell>
+    <clr-dg-cell>{{ item.hideableCol2 }}</clr-dg-cell>
+    <clr-dg-cell>{{ item.numericCol }}</clr-dg-cell>
+    <clr-dg-cell>{{ item.dateCol | date }}</clr-dg-cell>
+    <clr-dg-cell>{{ item.enumCol }}</clr-dg-cell>
+  </clr-dg-row>
+
+  <clr-dg-footer>
+    <clr-dg-pagination [clrDgPageSize]="15">
+      <clr-dg-page-size [clrPageSizeOptions]="[10,15,20,50,100]">Entries per page</clr-dg-page-size>
+    </clr-dg-pagination>
+  </clr-dg-footer>
+</clr-datagrid>


### PR DESCRIPTION
- Set current page earlier, so the first backend call already has the persisted page
- Adapt enum filter to not emit a filter change when filtering initial filter values. This triggered datagrid internal logic, which was not able to handle a not yet loaded page