### PR TITLE
[C3DEV-489453] Restores signpost & tooltip rendering to state before sorting extension

### DIFF
--- a/src/clr-addons/treetable/treetable.scss
+++ b/src/clr-addons/treetable/treetable.scss
@@ -346,7 +346,6 @@ $indentation-increment: 1rem;
             flex: 1 1 auto;
             flex-flow: row nowrap;
             overflow: hidden;
-            position: relative;
 
             .treetable-cell {
               text-align: left;

--- a/src/dev/src/app/treetable/treetable.demo.html
+++ b/src/dev/src/app/treetable/treetable.demo.html
@@ -683,7 +683,12 @@
         </clr-signpost>
       </clr-tt-cell>
       <clr-tt-cell class="text-truncate">{{node.type}}</clr-tt-cell>
-      <clr-tt-cell class="text-truncate">{{node.version}}</clr-tt-cell>
+      <clr-tt-cell class="text-truncate">
+        <clr-tooltip>
+          <span clrTooltipTrigger>{{node.version}}</span>
+          <clr-tooltip-content> This is a test tooltip! </clr-tooltip-content>
+        </clr-tooltip>
+      </clr-tt-cell>
       <ng-container ngProjectAs="clr-tt-row" *ngFor="let childNode of node.children">
         <ng-container *ngTemplateOutlet="signpostNode; context: { $implicit: childNode }"></ng-container>
       </ng-container>


### PR DESCRIPTION
Removes rendering with signposts and tooltips in the Treetable-component, introduced in extension.