### PR TITLE
Add persistColumnOrderTransformer in StatePersistenceOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clr-addons",
-  "version": "19.18.1",
+  "version": "19.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clr-addons",
-      "version": "19.18.1",
+      "version": "19.18.2",
       "dependencies": {
         "@angular/animations": "19.2.18",
         "@angular/cdk": "19.2.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "19.18.1",
+  "version": "19.18.2",
   "private": true,
   "scripts": {
     "build:ui:css": "sass --source-map --precision=8 ./src/clr-addons/themes/phs/phs-theme.scss ./dist/clr-addons/styles/clr-addons-phs.css",

--- a/src/clr-addons/datagrid/column-reorder/column-reorder.directive.ts
+++ b/src/clr-addons/datagrid/column-reorder/column-reorder.directive.ts
@@ -38,6 +38,10 @@ export class DatagridColumnReorderDirective<T extends { name: string }> implemen
         this.columnOrderChanged.next(value);
         // after change detection, columns need to be rerendered first
         setTimeout(() => this.updateSeparatorVisibility(), 0);
+        // After Angular has reordered the DOM,
+        // force Clarity to re-project columns in the new order by triggering its render cycle.
+        // DatagridRenderOrganizer is not publicly exported, so we access it via the datagrid instance.
+        setTimeout(() => (this.datagrid as any).organizer?.resize());
       },
     }
   );

--- a/src/clr-addons/datagrid/column-reorder/column-reorder.directive.ts
+++ b/src/clr-addons/datagrid/column-reorder/column-reorder.directive.ts
@@ -81,7 +81,7 @@ export class DatagridColumnReorderDirective<T extends { name: string }> implemen
   private updateColumnOrder(dragPreviousIndex: number, dragCurrentIndex: number): void {
     // we need to divide the indexes by two, because each column has two draggable elements:
     // - the column itself and the resize handle
-    const from = dragPreviousIndex / 2;
+    const from = Math.floor((dragPreviousIndex + 1) / 2);
     const to = Math.floor((dragCurrentIndex + 1) / 2);
     if (from === to) {
       // no change, do nothing

--- a/src/clr-addons/datagrid/column-reorder/column-reorder.directive.ts
+++ b/src/clr-addons/datagrid/column-reorder/column-reorder.directive.ts
@@ -14,6 +14,13 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { filter } from 'rxjs/operators';
 import { ClrDatagrid, ClrDatagridColumn } from '@clr/angular';
 
+interface ColumnOrderChangedEvent<T> {
+  columns: T[];
+  from?: number;
+  to?: number;
+  trigger: 'init' | 'drag' | 'reset';
+}
+
 @Directive({
   selector: '[clrDatagridColumnReorder]',
   host: {
@@ -24,12 +31,16 @@ import { ClrDatagrid, ClrDatagridColumn } from '@clr/angular';
 export class DatagridColumnReorderDirective<T extends { name: string }> implements OnInit {
   @Input('clrDatagridColumnReorder') columnDefinitions: T[] = [];
 
-  @Output('clrDatagridColumnOrderChanged') columnOrderChanged = new EventEmitter<{
-    columns: T[];
-    from?: number;
-    to?: number;
-    trigger: 'init' | 'drag';
-  }>();
+  @Output('clrDatagridColumnOrderChanged') columnOrderChanged = Object.assign(
+    new EventEmitter<ColumnOrderChangedEvent<T>>(),
+    {
+      emit: (value: ColumnOrderChangedEvent<T>) => {
+        this.columnOrderChanged.next(value);
+        // after change detection, columns need to be rerendered first
+        setTimeout(() => this.updateSeparatorVisibility(), 0);
+      },
+    }
+  );
 
   @ContentChildren(ClrDatagridColumn) public clrColumns: QueryList<ClrDatagridColumn>;
 
@@ -61,9 +72,10 @@ export class DatagridColumnReorderDirective<T extends { name: string }> implemen
   public initializeColumnOrder(storedOrder: Record<string, number>) {
     const orderedColumns = this.reconcileColumnOrder(this.columnDefinitions, storedOrder);
     this.columnOrderChanged.emit({ columns: orderedColumns, trigger: 'init' });
+  }
 
-    // after change detection, columns need to be rerendered first
-    setTimeout(() => this.updateSeparatorVisibility(), 0);
+  public resetColumnOrder(columns: T[]): void {
+    this.columnOrderChanged.emit({ columns, trigger: 'reset' });
   }
 
   // This is needed in case there is a new column, which is not stored in the storage.
@@ -91,9 +103,6 @@ export class DatagridColumnReorderDirective<T extends { name: string }> implemen
     const columnDefinitionCopy = [...this.columnDefinitions];
     moveItemInArray(columnDefinitionCopy, from, to);
     this.columnOrderChanged.emit({ columns: columnDefinitionCopy, from, to, trigger: 'drag' });
-
-    // after change detection, columns need to be rerendered first
-    setTimeout(() => this.updateSeparatorVisibility(), 0);
   }
 
   // show separator for all but the last visible column

--- a/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.directive.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.directive.ts
@@ -220,7 +220,9 @@ export class StatePersistenceKeyDirective implements AfterContentInit, OnDestroy
         // we skip the first value (init), because it's already coming from the local storage, so no need to save it again
         filter(({ trigger }) => trigger !== 'init')
       )
-      .subscribe(({ columns }) => this.persistColumnOrder(columns));
+      .subscribe(({ trigger, columns }) =>
+        trigger === 'reset' ? this.resetColumnOrder() : this.persistColumnOrder(columns)
+      );
   }
 
   private initColumnOrder(savedState: ClrDatagridStatePersistenceModel): void {
@@ -301,6 +303,17 @@ export class StatePersistenceKeyDirective implements AfterContentInit, OnDestroy
         state.columns[name] = state.columns[name] || {};
         state.columns[name].order = index;
       });
+    }
+
+    this.saveLocalStorageState(state);
+  }
+
+  private resetColumnOrder(): void {
+    const state = this.getLocalStorageState();
+    state.columns = state.columns || {};
+
+    for (const name in state.columns) {
+      state.columns[name].order = undefined;
     }
 
     this.saveLocalStorageState(state);

--- a/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.directive.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.directive.ts
@@ -104,7 +104,7 @@ export class StatePersistenceKeyDirective implements AfterContentInit, OnDestroy
 
     const columnOrderPersistenceEnabled = this.options.persistColumnOrder ?? false;
     if (columnOrderPersistenceEnabled && !!this.reorderDirective) {
-      this.initColumnOrderPersister(localStorageState);
+      this.initColumnOrderPersister();
       this.initColumnOrder(localStorageState);
     }
 
@@ -213,14 +213,14 @@ export class StatePersistenceKeyDirective implements AfterContentInit, OnDestroy
     this.datagrid.items.change.pipe(takeUntil(this.destroy$)).subscribe(() => this.updatePaginationDescription());
   }
 
-  private initColumnOrderPersister(state: ClrDatagridStatePersistenceModel) {
+  private initColumnOrderPersister() {
     this.reorderDirective.columnOrderChanged
       .pipe(
         takeUntil(this.destroy$),
         // we skip the first value (init), because it's already coming from the local storage, so no need to save it again
         filter(({ trigger }) => trigger !== 'init')
       )
-      .subscribe(({ columns }) => this.persistColumnOrder(state, columns));
+      .subscribe(({ columns }) => this.persistColumnOrder(columns));
   }
 
   private initColumnOrder(savedState: ClrDatagridStatePersistenceModel): void {
@@ -290,13 +290,18 @@ export class StatePersistenceKeyDirective implements AfterContentInit, OnDestroy
     }
   }
 
-  private persistColumnOrder(state: ClrDatagridStatePersistenceModel, columns: { name: string }[]): void {
+  private persistColumnOrder(columns: { name: string }[]): void {
+    const state = this.getLocalStorageState();
     state.columns = state.columns || {};
 
-    columns.forEach(({ name }, index) => {
-      state.columns[name] = state.columns[name] || {};
-      state.columns[name].order = index;
-    });
+    if (this.options.persistColumnOrderTransformer) {
+      this.options.persistColumnOrderTransformer(state, columns);
+    } else {
+      columns.forEach(({ name }, index) => {
+        state.columns[name] = state.columns[name] || {};
+        state.columns[name].order = index;
+      });
+    }
 
     this.saveLocalStorageState(state);
   }

--- a/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.spec.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.spec.ts
@@ -16,6 +16,7 @@ import { By } from '@angular/platform-browser';
 import { BehaviorSubject } from 'rxjs';
 import { ClrEnumFilterComponent, ClrEnumFilterModule } from '../enum-filter';
 import { CdkDrag, CdkDragDrop, CdkDropList } from '@angular/cdk/drag-drop';
+import { ClrDatagridStatePersistenceModel } from './datagrid-state-persistence-model.interface';
 
 @Component({
   template: `
@@ -28,7 +29,8 @@ import { CdkDrag, CdkDragDrop, CdkDropList } from '@angular/cdk/drag-drop';
         persistPagination,
         persistSort,
         persistColumnWidths,
-        persistColumnOrder
+        persistColumnOrder,
+        persistColumnOrderTransformer
       }"
       [clrPaginationDescription]="'{{first}} - {{last}} of {{total}} entries'"
       [clrDatagridColumnReorder]="columns"
@@ -105,6 +107,8 @@ class TestComponent {
   persistSort: boolean | undefined = false;
   persistColumnWidths: boolean | undefined = false;
   persistColumnOrder: boolean | undefined = false;
+  persistColumnOrderTransformer: (state: ClrDatagridStatePersistenceModel, columns: { name: string }[]) => void =
+    undefined;
 }
 
 const DEFAULT_PAGE_SIZE = 15;
@@ -504,6 +508,25 @@ describe('StatePersistenceKeyDirective', () => {
       fixture.detectChanges();
 
       expect(fixture.componentInstance.columns.map(c => c.name)).toEqual(['dynamic-column-1', 'dynamic-column-2']);
+    });
+
+    it('should use custom order transformer', () => {
+      const storageKey = PERSISTENCE_KEY + '-should-use-custom-transformer';
+      localStorage.setItem(storageKey, '{"columns":{"dynamic-column-1":{"order":1},"dynamic-column-2":{"order":2}}}');
+      fixture.componentInstance.storageKey = storageKey;
+      fixture.componentInstance.persistColumnOrder = true;
+      fixture.componentInstance.persistColumnOrderTransformer = (state, _columns) => {
+        // muliply the order by 10 for whatever reason
+        state.columns['dynamic-column-1'].order = 10 * state.columns['dynamic-column-1'].order;
+        state.columns['dynamic-column-2'].order = 10 * state.columns['dynamic-column-2'].order;
+      };
+      fixture.detectChanges();
+
+      fixture.componentInstance.dropList.dropped.emit(createCdkDropEvent(0, 1));
+
+      expect(localStorage.getItem(storageKey)).toEqual(
+        '{"columns":{"dynamic-column-1":{"order":10},"dynamic-column-2":{"order":20}}}'
+      );
     });
 
     function createCdkDropEvent(previousIndex: number, currentIndex: number): CdkDragDrop<unknown> {

--- a/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-options.interface.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-options.interface.ts
@@ -1,3 +1,5 @@
+import { ClrDatagridStatePersistenceModel } from './datagrid-state-persistence-model.interface';
+
 export interface StatePersistenceOptions {
   key: string;
   serverDriven: boolean;
@@ -7,4 +9,5 @@ export interface StatePersistenceOptions {
   persistHiddenColumns?: boolean;
   persistColumnWidths?: boolean;
   persistColumnOrder?: boolean;
+  persistColumnOrderTransformer?: (state: ClrDatagridStatePersistenceModel, columns: { name: string }[]) => void;
 }

--- a/src/clr-addons/package.json
+++ b/src/clr-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/clr-addons",
-  "version": "19.18.1",
+  "version": "19.18.2",
   "description": "Addon components for Clarity Angular",
   "es2015": "esm2015/clr-addons.js",
   "homepage": "https://porscheinformatik.github.io/clarity-addons/",


### PR DESCRIPTION
- Enable user controlled datagrid column order persitance transformer
- Fix from in column-reorder.directive can be between values
- Fix column order change subscription uses outdated stored state