### PR TITLE
feat(keyboard-nav): add keyboard navigation directives and demo

### DIFF
--- a/src/clr-addons/clr-addons.module.ts
+++ b/src/clr-addons/clr-addons.module.ts
@@ -46,9 +46,16 @@ import { ClrReadonlyDirectiveModule } from './readonly/readonly.module';
 import { ClrFocusFirstInvalidFieldDirective } from './focus-first-invalid-field';
 import { ClrControlEnterSubmitDirective } from './control-enter-submit';
 import { ClrSignpostAddonModule } from './signpost';
+import { ClrKeyboardNavCtrlArrowDirective } from './keyboard-nav/clr-keyboard-nav-ctrl-arrow.directive';
+import { ClrKeyboardNavAltMnemonicDirective } from './keyboard-nav/clr-keyboard-nav-alt-mnemonic.directive';
 
 @NgModule({
-  imports: [ClrFocusFirstInvalidFieldDirective, ClrControlEnterSubmitDirective],
+  imports: [
+    ClrFocusFirstInvalidFieldDirective,
+    ClrControlEnterSubmitDirective,
+    ClrKeyboardNavCtrlArrowDirective,
+    ClrKeyboardNavAltMnemonicDirective,
+  ],
   declarations: [],
   exports: [
     ClrViewEditSectionModule,
@@ -90,6 +97,8 @@ import { ClrSignpostAddonModule } from './signpost';
     ClrSignpostAddonModule,
     ClrFocusFirstInvalidFieldDirective,
     ClrControlEnterSubmitDirective,
+    ClrKeyboardNavCtrlArrowDirective,
+    ClrKeyboardNavAltMnemonicDirective,
   ],
 })
 export class ClrAddonsModule {}

--- a/src/clr-addons/components.clr-addons.scss
+++ b/src/clr-addons/components.clr-addons.scss
@@ -34,6 +34,7 @@
 @use 'readonly/readonly.directive.scss';
 @use 'datagrid/column-reorder/column-reorder.scss';
 @use 'charts/charts.scss';
+@use 'keyboard-nav/keyboard-nav';
 
 html,
 body,

--- a/src/clr-addons/index.ts
+++ b/src/clr-addons/index.ts
@@ -47,3 +47,4 @@ export * from './summary-area/index';
 export * from './signpost/index';
 export * from './focus-first-invalid-field/index';
 export * from './control-enter-submit/index';
+export * from './keyboard-nav/index';

--- a/src/clr-addons/keyboard-nav/clr-keyboard-nav-alt-mnemonic.directive.ts
+++ b/src/clr-addons/keyboard-nav/clr-keyboard-nav-alt-mnemonic.directive.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { AfterViewInit, Directive, ElementRef, HostListener, inject, Input, OnDestroy, Renderer2 } from '@angular/core';
+
+const DEFAULT_NAV_ITEM_SELECTOR = '[clrVerticalNavLink], [clrTabLink]';
+const MNEMONICS_VISIBLE_CLASS = 'clr-kbd-mnemonics-visible';
+const MNEMONIC_DATA_ATTR = 'data-clr-kbd-mnemonic';
+const ICON_SLOT_CLASS = 'clr-kbd-icon-slot';
+const MNEMONIC_BADGE_CLASS = 'clr-kbd-mnemonic-badge';
+/** Selector for functional/structural icons that must not be swapped out. */
+const EXCLUDED_ICON_SELECTOR = 'cds-icon.dropdown-icon, cds-icon[shape="angle"]';
+
+/**
+ * Directive that assigns sequential numeric keyboard mnemonics to navigation items
+ * and enables Alt-key-based navigation.
+ *
+ * - Mnemonics (1, 2, 3, ...) are assigned once at view initialisation and never change.
+ * - While Alt is held the CSS class `clr-kbd-mnemonics-visible` is added to the host,
+ *   causing numbered badges to appear on each item (styled via keyboard-nav.scss).
+ * - Digit keys pressed while Alt is held accumulate into a buffer.
+ * - When Alt is released the buffer is matched to a mnemonic and the item is activated.
+ * - Multi-digit: |Alt-down|, |1|, |1|, |Alt-up| navigates to item 11.
+ * - [Alt]+[Arrow] browser navigation is never overridden.
+ *
+ * @example
+ * ```html
+ * <clr-tabs clrKeyboardNavAltMnemonic>...</clr-tabs>
+ * <clr-vertical-nav clrKeyboardNavAltMnemonic>...</clr-vertical-nav>
+ * <div clrKeyboardNavAltMnemonic clrNavItemSelector=".my-btn" [clrNavDisabled]="overlayOpen">...</div>
+ * ```
+ */
+@Directive({
+  selector: '[clrKeyboardNavAltMnemonic]',
+  standalone: true,
+})
+export class ClrKeyboardNavAltMnemonicDirective implements AfterViewInit, OnDestroy {
+  /** CSS selector for the navigable items inside the host element. */
+  @Input() clrNavItemSelector: string = DEFAULT_NAV_ITEM_SELECTOR;
+
+  /** Set to true to disable navigation while an overlay or modal is active. */
+  @Input() clrNavDisabled = false;
+
+  private readonly el = inject(ElementRef);
+  private readonly renderer = inject(Renderer2);
+
+  /** Fixed mapping: mnemonic number -> nav item element (assigned once at init). */
+  private readonly mnemonicMap = new Map<number, HTMLElement>();
+
+  /** Map: mnemonic number → injected icon-slot wrapper span (null when no icon found). */
+  private readonly iconSlotMap = new Map<number, HTMLElement | null>();
+
+  /** Digit characters accumulated while Alt is held. */
+  private digitBuffer = '';
+
+  /** Whether the Alt key is currently pressed. */
+  private altKeyActive = false;
+
+  ngAfterViewInit(): void {
+    // Defer one tick to ensure projected content is fully rendered.
+    setTimeout(() => this.assignMnemonics(), 0);
+  }
+
+  ngOnDestroy(): void {
+    // Guard against the directive being destroyed while Alt is still held.
+    this.resetAltState();
+    // Unwrap any injected icon slots to leave the DOM clean.
+    this.iconSlotMap.forEach(slot => {
+      if (!slot) {
+        return;
+      }
+      const icon = slot.querySelector('cds-icon') as HTMLElement | null;
+      if (icon && slot.parentElement) {
+        this.renderer.insertBefore(slot.parentElement, icon, slot);
+        this.renderer.removeChild(slot.parentElement, slot);
+      }
+    });
+    this.iconSlotMap.clear();
+  }
+
+  @HostListener('window:keydown', ['$event'])
+  onWindowKeyDown(event: KeyboardEvent): void {
+    if (this.clrNavDisabled) {
+      return;
+    }
+
+    if (event.key === 'Alt') {
+      this.altKeyActive = true;
+      this.digitBuffer = '';
+      this.renderer.addClass(this.el.nativeElement, MNEMONICS_VISIBLE_CLASS);
+      // Suppress browser menu-bar activation on Windows/Linux.
+      event.preventDefault();
+      return;
+    }
+
+    // Accumulate digits while Alt is held.
+    // Arrow keys are NOT handled here to preserve [Alt+Arrow] browser history navigation.
+    if (this.altKeyActive && /^\d$/.test(event.key)) {
+      this.digitBuffer += event.key;
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+
+  @HostListener('window:keyup', ['$event'])
+  onWindowKeyUp(event: KeyboardEvent): void {
+    if (event.key !== 'Alt') {
+      return;
+    }
+
+    const bufferSnapshot = this.digitBuffer;
+    this.resetAltState();
+
+    if (this.clrNavDisabled || !bufferSnapshot) {
+      return;
+    }
+
+    const mnemonic = parseInt(bufferSnapshot, 10);
+    const target = this.mnemonicMap.get(mnemonic);
+    if (target) {
+      target.click();
+    }
+  }
+
+  /**
+   * Reset state when the window loses focus (e.g. Alt+Tab to another app).
+   * Without this the badge overlay could remain visible indefinitely.
+   */
+  @HostListener('window:blur')
+  onWindowBlur(): void {
+    this.resetAltState();
+  }
+
+  private assignMnemonics(): void {
+    const items = Array.from(this.el.nativeElement.querySelectorAll(this.clrNavItemSelector)) as HTMLElement[];
+
+    this.mnemonicMap.clear();
+    this.iconSlotMap.clear();
+
+    items.forEach((item, index) => {
+      const mnemonic = index + 1;
+      this.mnemonicMap.set(mnemonic, item);
+      this.renderer.setAttribute(item, MNEMONIC_DATA_ATTR, String(mnemonic));
+
+      // Find first cds-icon that is not a structural/functional icon.
+      const excludedIcons = new Set(Array.from(item.querySelectorAll(EXCLUDED_ICON_SELECTOR)));
+      const icon = Array.from(item.querySelectorAll('cds-icon')).find(el => !excludedIcons.has(el)) as
+        | HTMLElement
+        | undefined;
+
+      if (icon) {
+        // Wrap the icon so the badge can be absolutely positioned inside it.
+        const slot: HTMLElement = this.renderer.createElement('span');
+        this.renderer.addClass(slot, ICON_SLOT_CLASS);
+        this.renderer.insertBefore(icon.parentElement!, slot, icon);
+        this.renderer.appendChild(slot, icon);
+
+        // Badge span — sits on top of the (hidden) icon.
+        const badge: HTMLElement = this.renderer.createElement('span');
+        this.renderer.addClass(badge, MNEMONIC_BADGE_CLASS);
+        this.renderer.setAttribute(badge, 'aria-hidden', 'true');
+        badge.textContent = String(mnemonic);
+        this.renderer.appendChild(slot, badge);
+
+        this.iconSlotMap.set(mnemonic, slot);
+      } else {
+        this.iconSlotMap.set(mnemonic, null);
+      }
+    });
+  }
+
+  private resetAltState(): void {
+    this.altKeyActive = false;
+    this.digitBuffer = '';
+    this.renderer.removeClass(this.el.nativeElement, MNEMONICS_VISIBLE_CLASS);
+  }
+}

--- a/src/clr-addons/keyboard-nav/clr-keyboard-nav-ctrl-arrow.directive.ts
+++ b/src/clr-addons/keyboard-nav/clr-keyboard-nav-ctrl-arrow.directive.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { AfterViewInit, Directive, ElementRef, HostListener, inject, Input } from '@angular/core';
+
+/** Default CSS selector matching navigable items in common Clarity navigation components. */
+const DEFAULT_NAV_ITEM_SELECTOR = '[clrVerticalNavLink], [clrTabLink]';
+
+/**
+ * Directive that enables circular keyboard navigation using Ctrl+Arrow keys.
+ *
+ * - **Ctrl+Left** / **Ctrl+Up**: navigate to the previous item (wraps to last).
+ * - **Ctrl+Right** / **Ctrl+Down**: navigate to the next item (wraps to first).
+ *
+ * The order of items is fixed at the time the page loads and does not change for
+ * the lifetime of the directive, regardless of visual reordering (e.g. overflow menus).
+ *
+ * Navigation is suppressed while `clrNavDisabled` is `true` (e.g. when an overlay is open).
+ *
+ * @example
+ * ```html
+ * <!-- Horizontal navigation (tabs) -->
+ * <clr-tabs clrKeyboardNavCtrlArrow clrNavOrientation="horizontal">…</clr-tabs>
+ *
+ * <!-- Vertical navigation (sidebar) -->
+ * <clr-vertical-nav clrKeyboardNavCtrlArrow clrNavOrientation="vertical">…</clr-vertical-nav>
+ *
+ * <!-- Custom selector + overlay guard -->
+ * <div clrKeyboardNavCtrlArrow
+ *      clrNavItemSelector=".my-nav-btn"
+ *      [clrNavDisabled]="isOverlayOpen">…</div>
+ * ```
+ */
+@Directive({
+  selector: '[clrKeyboardNavCtrlArrow]',
+  standalone: true,
+})
+export class ClrKeyboardNavCtrlArrowDirective implements AfterViewInit {
+  /**
+   * CSS selector for the navigable items inside the host element.
+   * Defaults to Clarity's vertical-nav links and tab-links.
+   */
+  @Input() clrNavItemSelector: string = DEFAULT_NAV_ITEM_SELECTOR;
+
+  /**
+   * Restricts which arrow directions trigger navigation:
+   * - `'horizontal'` – only Ctrl+Left / Ctrl+Right
+   * - `'vertical'`   – only Ctrl+Up   / Ctrl+Down
+   * - `'both'`       – all four directions (default)
+   */
+  @Input() clrNavOrientation: 'horizontal' | 'vertical' | 'both' = 'both';
+
+  /**
+   * Set to `true` to temporarily disable all keyboard navigation,
+   * e.g. while an overlay or modal dialog is open.
+   */
+  @Input() clrNavDisabled = false;
+
+  private readonly el = inject(ElementRef);
+
+  /** Items captured at initialization time – order is fixed per spec. */
+  private navItems: HTMLElement[] = [];
+
+  ngAfterViewInit(): void {
+    // Defer one tick to ensure the host component has projected and rendered all content.
+    setTimeout(() => {
+      this.navItems = Array.from(this.el.nativeElement.querySelectorAll(this.clrNavItemSelector)) as HTMLElement[];
+    }, 0);
+  }
+
+  @HostListener('window:keydown', ['$event'])
+  onWindowKeyDown(event: KeyboardEvent): void {
+    if (this.clrNavDisabled || !event.ctrlKey) {
+      return;
+    }
+
+    const { key } = event;
+    const isLeft = key === 'ArrowLeft';
+    const isRight = key === 'ArrowRight';
+    const isUp = key === 'ArrowUp';
+    const isDown = key === 'ArrowDown';
+
+    if (!isLeft && !isRight && !isUp && !isDown) {
+      return;
+    }
+    if (this.clrNavOrientation === 'horizontal' && (isUp || isDown)) {
+      return;
+    }
+    if (this.clrNavOrientation === 'vertical' && (isLeft || isRight)) {
+      return;
+    }
+
+    // Filter out items that are currently not reachable.
+    const navigable = this.navItems.filter(item => this.isNavigable(item));
+    if (!navigable.length) {
+      return;
+    }
+
+    const currentIndex = this.findActiveIndex(navigable);
+    let nextIndex: number;
+
+    if (isLeft || isUp) {
+      // Backward – wrap to last item when on first.
+      nextIndex = currentIndex <= 0 ? navigable.length - 1 : currentIndex - 1;
+    } else {
+      // Forward – wrap to first item when on last.
+      nextIndex = currentIndex >= navigable.length - 1 ? 0 : currentIndex + 1;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    navigable[nextIndex].click();
+  }
+
+  /** Returns `true` when the item is currently usable (not hidden, not disabled). */
+  private isNavigable(item: HTMLElement): boolean {
+    return !item.hidden && !(item as HTMLButtonElement).disabled;
+  }
+
+  /**
+   * Returns the index of the currently active item, or `-1` if none is found.
+   * Checks `aria-current`, `aria-selected="true"`, and the `.active` CSS class.
+   */
+  private findActiveIndex(items: HTMLElement[]): number {
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (
+        item.hasAttribute('aria-current') ||
+        item.getAttribute('aria-selected') === 'true' ||
+        item.classList.contains('active')
+      ) {
+        return i;
+      }
+    }
+    // No active item found – returning -1 causes the first/last item to be selected
+    // on the next navigation event, which is intuitive fallback behaviour.
+    return -1;
+  }
+}

--- a/src/clr-addons/keyboard-nav/index.ts
+++ b/src/clr-addons/keyboard-nav/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export * from './clr-keyboard-nav-ctrl-arrow.directive';
+export * from './clr-keyboard-nav-alt-mnemonic.directive';

--- a/src/clr-addons/keyboard-nav/keyboard-nav.scss
+++ b/src/clr-addons/keyboard-nav/keyboard-nav.scss
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+// Keyboard mnemonic badges
+// Shown on each nav item while the Alt key is held on a host decorated with
+// [clrKeyboardNavAltMnemonic]. The numeric value comes from the directive's
+// data attribute; colours reuse Clarity's primary-button tokens so the badge
+// adapts automatically to the active theme.
+//
+// Two rendering paths:
+//   1. Icon-swap  – the directive wraps the first cds-icon in .clr-kbd-icon-slot
+//                   and injects a sibling .clr-kbd-mnemonic-badge.  When Alt is
+//                   held the icon is hidden and the badge fills its space.
+//   2. Fallback   – nav items with no icon use a ::before pseudo-element badge.
+
+// ─── Shared visual properties ─────────────────────────────────────────────────
+
+@mixin badge-appearance {
+  box-sizing: border-box;
+  height: 16px;
+  min-width: 16px;
+  padding: 1px 4px 0;
+  // Pill radius works for both 1- and 2-digit mnemonics (border-radius: 50%
+  // would create an ellipse when width > height for two digits).
+  border-radius: 8px;
+
+  background-color: #fff;
+  border: 1.5px solid var(--cds-alias-status-alt, #0079b8);
+  color: var(--cds-alias-status-alt, #0079b8);
+
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+
+  pointer-events: none;
+  z-index: 100;
+}
+
+// ─── Icon-slot wrapper ────────────────────────────────────────────────────────
+
+.clr-kbd-icon-slot {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  align-self: center;
+}
+
+// ─── Path 1 badge (hidden by default, shown when Alt is held) ─────────────────
+
+.clr-kbd-mnemonic-badge {
+  display: none;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  flex-shrink: 0;
+  @include badge-appearance;
+}
+
+// ─── Active state (Alt held) ─────────────────────────────────────────────────
+
+.clr-kbd-mnemonics-visible {
+  // Path 1: hide icon, show badge.
+  .clr-kbd-icon-slot {
+    cds-icon {
+      visibility: hidden;
+    }
+
+    .clr-kbd-mnemonic-badge {
+      display: inline-flex;
+      // Override any colour/size changes from Clarity's active or hover state.
+      background-color: #fff !important;
+      border-color: var(--cds-alias-status-alt, #0079b8) !important;
+      color: var(--cds-alias-status-alt, #0079b8) !important;
+      height: 16px !important;
+      min-width: 16px !important;
+      width: auto !important;
+    }
+  }
+
+  // Path 2: fallback via ::after (no icon present).
+  // NOTE: ::before is intentionally avoided – Clarity's active-tab bottom
+  // indicator is drawn with ::before on the same button element.  Using ::after
+  // leaves that indicator untouched.
+  [data-clr-kbd-mnemonic]:not(:has(.clr-kbd-icon-slot)) {
+    position: relative !important;
+
+    &::after {
+      content: attr(data-clr-kbd-mnemonic);
+      display: inline-flex;
+      position: absolute;
+      top: 50%;
+      left: 0.3rem;
+      right: auto !important;
+      width: auto !important;
+      transform: translateY(-50%);
+      @include badge-appearance;
+      // Ensure identical appearance regardless of active / hover state on the
+      // parent (mirrors the !important overrides used in Path 1).
+      background-color: #fff !important;
+      border-color: var(--cds-alias-status-alt, #0079b8) !important;
+      color: var(--cds-alias-status-alt, #0079b8) !important;
+      height: 16px !important;
+      min-width: 16px !important;
+    }
+  }
+}

--- a/src/dev/src/app/app.routing.ts
+++ b/src/dev/src/app/app.routing.ts
@@ -206,6 +206,10 @@ export const APP_ROUTES: Routes = [
     path: 'ctrl-enter',
     loadChildren: () => import('./ctrl-enter/ctrl-enter.demo.module').then(m => m.CtrlEnterDemoModule),
   },
+  {
+    path: 'keyboard-nav',
+    loadComponent: () => import('./keyboard-nav/keyboard-nav.demo').then(m => m.KeyboardNavDemo),
+  },
 ];
 
 export const ROUTING: ModuleWithProviders<RouterModule> = RouterModule.forRoot(APP_ROUTES);

--- a/src/dev/src/app/keyboard-nav/keyboard-nav.demo.html
+++ b/src/dev/src/app/keyboard-nav/keyboard-nav.demo.html
@@ -1,0 +1,256 @@
+<!--
+  ~ Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h2>Keyboard Navigation</h2>
+<p>
+  Two standalone directives add keyboard-driven navigation to any Clarity navigation component (<code>clr-tabs</code>,
+  <code>clr-vertical-nav</code>, or any custom host).
+</p>
+
+<!-- ─── Ctrl+Arrow ──────────────────────────────────────────────────────────── -->
+<h3>1. clrKeyboardNavCtrlArrow</h3>
+<p>
+  Add <code>clrKeyboardNavCtrlArrow</code> to a navigation host. While focus is anywhere on the page, use
+  <kbd>Ctrl+Left</kbd> / <kbd>Ctrl+Right</kbd> to cycle through tabs (or <kbd>Ctrl+Up</kbd> / <kbd>Ctrl+Down</kbd> for a
+  vertical nav). Navigation wraps around at both ends.
+</p>
+<p><strong>Try it:</strong> press <kbd>Ctrl+Right</kbd> / <kbd>Ctrl+Left</kbd> to switch tabs.</p>
+
+<clr-tabs clrKeyboardNavCtrlArrow clrNavOrientation="horizontal">
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="home"></cds-icon> Category 1</button>
+    <clr-tab-content *clrIfActive="true">
+      <div style="padding: 1rem">
+        <strong>Category 1</strong> — press <kbd>Ctrl+Right</kbd> to go forward, <kbd>Ctrl+Left</kbd> from here wraps to
+        the last tab.
+      </div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="cog"></cds-icon> Category 2</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Category 2</strong></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="user"></cds-icon> Category 3</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Category 3</strong></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="bell"></cds-icon> Category 4</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Category 4</strong> — <kbd>Ctrl+Right</kbd> wraps back to Category 1.</div>
+    </clr-tab-content>
+  </clr-tab>
+</clr-tabs>
+
+<!-- ─── Alt+Mnemonic ───────────────────────────────────────────────────────── -->
+<h3>2. clrKeyboardNavAltMnemonic</h3>
+<p>
+  Add <code>clrKeyboardNavAltMnemonic</code> to a navigation host. Numeric mnemonics (1, 2, 3, …) are assigned to each
+  item at page load and never change. Hold <kbd>Alt</kbd> to reveal the badge overlays, then type the digit(s) and
+  release <kbd>Alt</kbd> to navigate.
+</p>
+<p>
+  <strong>Multi-digit test:</strong> <kbd>Alt</kbd> held → <kbd>1</kbd> → <kbd>0</kbd> → <kbd>Alt</kbd> released
+  navigates to item&nbsp;10. There are 11 tabs below so both <kbd>Alt+10</kbd> and <kbd>Alt+11</kbd> require two
+  keystrokes.
+</p>
+<p><strong>Try it:</strong> hold <kbd>Alt</kbd> to see the badges, then press a digit (or two).</p>
+
+<clr-tabs clrKeyboardNavAltMnemonic>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="star"></cds-icon> Alpha</button>
+    <clr-tab-content *clrIfActive="true">
+      <div style="padding: 1rem"><strong>Alpha</strong> — mnemonic <kbd>Alt+1</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="heart"></cds-icon> Beta</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Beta</strong> — mnemonic <kbd>Alt+2</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="bolt"></cds-icon> Gamma</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Gamma</strong> — mnemonic <kbd>Alt+3</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="flag"></cds-icon> Delta</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Delta</strong> — mnemonic <kbd>Alt+4</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="search"></cds-icon> Epsilon</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Epsilon</strong> — mnemonic <kbd>Alt+5</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="folder"></cds-icon> Zeta</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Zeta</strong> — mnemonic <kbd>Alt+6</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="calendar"></cds-icon> Eta</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Eta</strong> — mnemonic <kbd>Alt+7</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="map"></cds-icon> Theta</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Theta</strong> — mnemonic <kbd>Alt+8</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="terminal"></cds-icon> Iota</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Iota</strong> — mnemonic <kbd>Alt+9</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="shield"></cds-icon> Kappa</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem">
+        <strong>Kappa</strong> — two-digit mnemonic <kbd>Alt</kbd>+<kbd>1</kbd><kbd>0</kbd>
+      </div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="clock"></cds-icon> Lambda</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem">
+        <strong>Lambda</strong> — two-digit mnemonic <kbd>Alt</kbd>+<kbd>1</kbd><kbd>1</kbd>
+      </div>
+    </clr-tab-content>
+  </clr-tab>
+</clr-tabs>
+
+<!-- ─── Alt+Mnemonic with icons ───────────────────────────────────────────── -->
+<h3>2b. clrKeyboardNavAltMnemonic – vertical nav with icons</h3>
+<p>
+  The <code>cds-icon</code> in front of each label is replaced <em>in-place</em> by the circle badge when
+  <kbd>Alt</kbd> is held — no layout shift.
+</p>
+<p><strong>Try it:</strong> hold <kbd>Alt</kbd> to see the badges, then press a digit.</p>
+
+<div style="max-width: 220px">
+  <clr-vertical-nav clrKeyboardNavAltMnemonic>
+    <a
+      clrVerticalNavLink
+      href="#"
+      [class.active]="activeVerticalNavItem === 'Home'"
+      (click)="activeVerticalNavItem = 'Home'; $event.preventDefault()"
+    >
+      <cds-icon clrVerticalNavIcon shape="home"></cds-icon>
+      Home
+    </a>
+    <a
+      clrVerticalNavLink
+      href="#"
+      [class.active]="activeVerticalNavItem === 'Search'"
+      (click)="activeVerticalNavItem = 'Search'; $event.preventDefault()"
+    >
+      <cds-icon clrVerticalNavIcon shape="search"></cds-icon>
+      Search
+    </a>
+    <a
+      clrVerticalNavLink
+      href="#"
+      [class.active]="activeVerticalNavItem === 'Profile'"
+      (click)="activeVerticalNavItem = 'Profile'; $event.preventDefault()"
+    >
+      <cds-icon clrVerticalNavIcon shape="user"></cds-icon>
+      Profile
+    </a>
+    <a
+      clrVerticalNavLink
+      href="#"
+      [class.active]="activeVerticalNavItem === 'Documents'"
+      (click)="activeVerticalNavItem = 'Documents'; $event.preventDefault()"
+    >
+      <cds-icon clrVerticalNavIcon shape="folder"></cds-icon>
+      Documents
+    </a>
+    <a
+      clrVerticalNavLink
+      href="#"
+      [class.active]="activeVerticalNavItem === 'Notifications'"
+      (click)="activeVerticalNavItem = 'Notifications'; $event.preventDefault()"
+    >
+      <cds-icon clrVerticalNavIcon shape="bell"></cds-icon>
+      Notifications
+    </a>
+    <a
+      clrVerticalNavLink
+      href="#"
+      [class.active]="activeVerticalNavItem === 'Settings'"
+      (click)="activeVerticalNavItem = 'Settings'; $event.preventDefault()"
+    >
+      <cds-icon clrVerticalNavIcon shape="cog"></cds-icon>
+      Settings
+    </a>
+  </clr-vertical-nav>
+</div>
+<p style="margin-top: 0.5rem">Active: <strong>{{ activeVerticalNavItem }}</strong></p>
+
+<!-- ─── Both combined ─────────────────────────────────────────────────────── -->
+<h3>3. Both directives combined</h3>
+<p>Apply both directives to the same host. Use either <kbd>Ctrl+Arrow</kbd> or <kbd>Alt+digit</kbd> to navigate.</p>
+<p>
+  Overlay guard demo: check the checkbox to simulate an active overlay — both shortcuts will be deactivated while it is
+  checked.
+</p>
+
+<label style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem">
+  <input type="checkbox" [(ngModel)]="overlayActive" />
+  Simulate overlay active (<code>[clrNavDisabled]="overlayActive"</code>)
+</label>
+
+<clr-tabs
+  clrKeyboardNavCtrlArrow
+  clrKeyboardNavAltMnemonic
+  clrNavOrientation="horizontal"
+  [clrNavDisabled]="overlayActive"
+>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="wrench"></cds-icon> Service</button>
+    <clr-tab-content *clrIfActive="true">
+      <div style="padding: 1rem"><strong>Service</strong> — <kbd>Alt+1</kbd> / <kbd>Ctrl+Left/Right</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="blocks-group"></cds-icon> Parts</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Parts</strong> — <kbd>Alt+2</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="inbox"></cds-icon> Package</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Package</strong> — <kbd>Alt+3</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="drop"></cds-icon> Fluid</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Fluid</strong> — <kbd>Alt+4</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink><cds-icon shape="circle"></cds-icon> Tyres</button>
+    <clr-tab-content *clrIfActive>
+      <div style="padding: 1rem"><strong>Tyres</strong> — <kbd>Alt+5</kbd></div>
+    </clr-tab-content>
+  </clr-tab>
+</clr-tabs>

--- a/src/dev/src/app/keyboard-nav/keyboard-nav.demo.ts
+++ b/src/dev/src/app/keyboard-nav/keyboard-nav.demo.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { ClrKeyboardNavCtrlArrowDirective, ClrKeyboardNavAltMnemonicDirective } from '@porscheinformatik/clr-addons';
+import { ClarityIcons, homeIcon, cogIcon, userIcon, searchIcon, folderIcon, bellIcon } from '@cds/core/icon';
+
+ClarityIcons.addIcons(homeIcon, cogIcon, userIcon, searchIcon, folderIcon, bellIcon);
+
+export const IMPORT_EXAMPLE = `// app.module.ts  (or any NgModule / standalone component)
+import {
+  ClrKeyboardNavCtrlArrowDirective,
+  ClrKeyboardNavAltMnemonicDirective,
+} from '@porscheinformatik/clr-addons';
+
+@NgModule({
+  imports: [
+    ClrKeyboardNavCtrlArrowDirective,
+    ClrKeyboardNavAltMnemonicDirective,
+    // … or simply import ClrAddonsModule
+  ],
+})
+export class AppModule {}`;
+
+export const CTRL_ARROW_BASIC_EXAMPLE = `<!-- Add clrKeyboardNavCtrlArrow to any Clarity navigation host -->
+
+<!-- Horizontal tabs: Ctrl+Left / Ctrl+Right cycle through tabs -->
+<clr-tabs clrKeyboardNavCtrlArrow clrNavOrientation="horizontal">
+  <clr-tab>
+    <button clrTabLink>Category 1</button>
+    <clr-tab-content *clrIfActive="true">...</clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink>Category 2</button>
+    <clr-tab-content *clrIfActive>...</clr-tab-content>
+  </clr-tab>
+</clr-tabs>
+
+<!-- Vertical sidebar: Ctrl+Up / Ctrl+Down cycle through links -->
+<clr-vertical-nav clrKeyboardNavCtrlArrow clrNavOrientation="vertical">
+  <a clrVerticalNavLink routerLink="./a" routerLinkActive="active">Item A</a>
+  <a clrVerticalNavLink routerLink="./b" routerLinkActive="active">Item B</a>
+</clr-vertical-nav>
+
+<!-- Disable while an overlay or modal is open -->
+<clr-tabs clrKeyboardNavCtrlArrow [clrNavDisabled]="isOverlayOpen">...</clr-tabs>
+
+<!-- Custom item selector (any host element) -->
+<div clrKeyboardNavCtrlArrow clrNavItemSelector=".my-nav-btn">...</div>`;
+
+export const ALT_MNEMONIC_BASIC_EXAMPLE = `<!-- Add clrKeyboardNavAltMnemonic to any Clarity navigation host -->
+
+<!-- Tabs: hold Alt to reveal badges, then press the digit -->
+<clr-tabs clrKeyboardNavAltMnemonic>
+  <clr-tab>
+    <button clrTabLink>Alpha</button>
+    <clr-tab-content *clrIfActive="true">...</clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink>Beta</button>
+    <clr-tab-content *clrIfActive>...</clr-tab-content>
+  </clr-tab>
+  <!-- Items 10, 11, ... require two digits: Alt + 1 + 0, Alt + 1 + 1 -->
+</clr-tabs>
+
+<!-- Vertical nav with icons — icon is swapped in-place by the badge (no layout shift) -->
+<clr-vertical-nav clrKeyboardNavAltMnemonic>
+  <a clrVerticalNavLink routerLink="./home" routerLinkActive="active">
+    <cds-icon clrVerticalNavIcon shape="home"></cds-icon>
+    Home
+  </a>
+  <a clrVerticalNavLink routerLink="./settings" routerLinkActive="active">
+    <cds-icon clrVerticalNavIcon shape="cog"></cds-icon>
+    Settings
+  </a>
+</clr-vertical-nav>
+
+<!-- Disable while an overlay is open -->
+<clr-tabs clrKeyboardNavAltMnemonic [clrNavDisabled]="isOverlayOpen">...</clr-tabs>`;
+
+export const COMBINED_EXAMPLE = `<!-- Both directives can be applied to the same host element -->
+<!-- Use Ctrl+Arrow OR Alt+digit interchangeably -->
+<clr-tabs
+  clrKeyboardNavCtrlArrow
+  clrKeyboardNavAltMnemonic
+  clrNavOrientation="horizontal"
+  [clrNavDisabled]="overlayActive">
+  <clr-tab>
+    <button clrTabLink>Service</button>
+    <clr-tab-content *clrIfActive="true">...</clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink>Parts</button>
+    <clr-tab-content *clrIfActive>...</clr-tab-content>
+  </clr-tab>
+</clr-tabs>
+
+<!-- Overlay guard: disable both shortcuts while a modal / overlay is open -->
+<label>
+  <input type="checkbox" [(ngModel)]="overlayActive" />
+  Overlay active
+</label>`;
+
+@Component({
+  selector: 'keyboard-nav-demo',
+  templateUrl: './keyboard-nav.demo.html',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    ClarityModule,
+    ClrKeyboardNavCtrlArrowDirective,
+    ClrKeyboardNavAltMnemonicDirective,
+  ],
+})
+export class KeyboardNavDemo {
+  overlayActive = false;
+  activeVerticalNavItem = 'Home';
+
+  importExample = IMPORT_EXAMPLE;
+  ctrlArrowExample = CTRL_ARROW_BASIC_EXAMPLE;
+  altMnemonicExample = ALT_MNEMONIC_BASIC_EXAMPLE;
+  combinedExample = COMBINED_EXAMPLE;
+}

--- a/website/src/app/documentation/demos/keyboard-nav/keyboard-nav-examples.demo.ts
+++ b/website/src/app/documentation/demos/keyboard-nav/keyboard-nav-examples.demo.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export const CTRL_ARROW_BASIC_EXAMPLE = `<!-- Add clrKeyboardNavCtrlArrow to any Clarity navigation host -->
+
+<!-- Horizontal tabs: Ctrl+Left / Ctrl+Right cycle through tabs -->
+<clr-tabs clrKeyboardNavCtrlArrow clrNavOrientation="horizontal">
+  <clr-tab>
+    <button clrTabLink>Category 1</button>
+    <clr-tab-content *clrIfActive="true">...</clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink>Category 2</button>
+    <clr-tab-content *clrIfActive>...</clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink>Category 3</button>
+    <clr-tab-content *clrIfActive>...</clr-tab-content>
+  </clr-tab>
+</clr-tabs>
+
+<!-- Vertical sidebar: Ctrl+Up / Ctrl+Down cycle through links -->
+<clr-vertical-nav clrKeyboardNavCtrlArrow clrNavOrientation="vertical">
+  <a clrVerticalNavLink routerLink="./a" routerLinkActive="active">Item A</a>
+  <a clrVerticalNavLink routerLink="./b" routerLinkActive="active">Item B</a>
+</clr-vertical-nav>
+
+<!-- Disable while an overlay or modal is open -->
+<clr-tabs clrKeyboardNavCtrlArrow [clrNavDisabled]="isOverlayOpen">...</clr-tabs>
+
+<!-- Custom item selector (any host element) -->
+<div clrKeyboardNavCtrlArrow clrNavItemSelector=".my-nav-btn">...</div>`;
+
+export const ALT_MNEMONIC_BASIC_EXAMPLE = `<!-- Add clrKeyboardNavAltMnemonic to any Clarity navigation host -->
+
+<!-- Tabs: hold Alt to reveal badges, then press the digit -->
+<clr-tabs clrKeyboardNavAltMnemonic>
+  <clr-tab>
+    <button clrTabLink>Alpha</button>
+    <clr-tab-content *clrIfActive="true">...</clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink>Beta</button>
+    <clr-tab-content *clrIfActive>...</clr-tab-content>
+  </clr-tab>
+  <!-- Items 10, 11, ... require two digits: Alt + 1 + 0, Alt + 1 + 1 -->
+</clr-tabs>
+
+<!-- Vertical nav with icons — icon is swapped in-place by the badge (no layout shift) -->
+<clr-vertical-nav clrKeyboardNavAltMnemonic>
+  <a clrVerticalNavLink routerLink="./home" routerLinkActive="active">
+    <cds-icon clrVerticalNavIcon shape="home"></cds-icon>
+    Home
+  </a>
+  <a clrVerticalNavLink routerLink="./settings" routerLinkActive="active">
+    <cds-icon clrVerticalNavIcon shape="cog"></cds-icon>
+    Settings
+  </a>
+</clr-vertical-nav>
+
+<!-- Disable while an overlay is open -->
+<clr-tabs clrKeyboardNavAltMnemonic [clrNavDisabled]="isOverlayOpen">...</clr-tabs>`;
+
+export const COMBINED_EXAMPLE = `<!-- Both directives can be applied to the same host element -->
+<!-- Use Ctrl+Arrow OR Alt+digit interchangeably -->
+<clr-tabs
+  clrKeyboardNavCtrlArrow
+  clrKeyboardNavAltMnemonic
+  clrNavOrientation="horizontal"
+  [clrNavDisabled]="overlayActive">
+  <clr-tab>
+    <button clrTabLink>Service</button>
+    <clr-tab-content *clrIfActive="true">...</clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink>Parts</button>
+    <clr-tab-content *clrIfActive>...</clr-tab-content>
+  </clr-tab>
+  <clr-tab>
+    <button clrTabLink>Package</button>
+    <clr-tab-content *clrIfActive>...</clr-tab-content>
+  </clr-tab>
+</clr-tabs>
+
+<!-- Overlay guard: disable both shortcuts while a modal / overlay is open -->
+<label>
+  <input type="checkbox" [(ngModel)]="overlayActive" />
+  Overlay active
+</label>`;
+
+export const IMPORT_EXAMPLE = `// app.module.ts  (or any NgModule / standalone component)
+import {
+  ClrKeyboardNavCtrlArrowDirective,
+  ClrKeyboardNavAltMnemonicDirective,
+} from '@porscheinformatik/clr-addons';
+
+@NgModule({
+  imports: [
+    ClrKeyboardNavCtrlArrowDirective,
+    ClrKeyboardNavAltMnemonicDirective,
+    // … or simply import ClrAddonsModule
+  ],
+})
+export class AppModule {}`;

--- a/website/src/app/documentation/demos/keyboard-nav/keyboard-nav.demo.html
+++ b/website/src/app/documentation/demos/keyboard-nav/keyboard-nav.demo.html
@@ -1,0 +1,445 @@
+<!--
+  ~ Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<clr-doc-wrapper [title]="title" [showTabs]="false">
+  <article>
+    <!-- ─── Table of Contents ──────────────────────────────────────────────── -->
+    @if (tableOfContents && tableOfContents.length) {
+    <div class="table-of-contents">
+      <span class="title">Content</span>
+      <ng-container *ngTemplateOutlet="tocList; context: { $implicit: tableOfContents }"></ng-container>
+    </div>
+    }
+
+    <!-- ─── Intro ─────────────────────────────────────────────────────────── -->
+    <h5 class="component-summary" id="keyboard-nav-header">
+      Two standalone directives — <code class="clr-code">clrKeyboardNavCtrlArrow</code> and
+      <code class="clr-code">clrKeyboardNavAltMnemonic</code> — add keyboard-driven navigation to any Clarity navigation
+      component (<code class="clr-code">clr-tabs</code>, <code class="clr-code">clr-vertical-nav</code>, or any custom
+      host element) without changing the existing DOM structure.
+    </h5>
+
+    <!-- ─── Import ────────────────────────────────────────────────────────── -->
+    <h2 id="import">Import</h2>
+    <p>Import the directives individually or via <code class="clr-code">ClrAddonsModule</code>:</p>
+    <clr-code-snippet [clrCode]="importExample"></clr-code-snippet>
+
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         1. Ctrl+Arrow
+    ════════════════════════════════════════════════════════════════════════ -->
+    <h2 id="ctrl-arrow">clrKeyboardNavCtrlArrow</h2>
+    <p>
+      Adds circular keyboard navigation using <kbd>Ctrl+Arrow</kbd> keys. Attach the directive to any Clarity navigation
+      host and navigate without ever leaving the keyboard.
+    </p>
+    <ul>
+      <li><kbd>Ctrl+Left</kbd> / <kbd>Ctrl+Up</kbd> — previous item (wraps to last).</li>
+      <li><kbd>Ctrl+Right</kbd> / <kbd>Ctrl+Down</kbd> — next item (wraps to first).</li>
+      <li>Item order is captured once at page load and never changes.</li>
+      <li>Works globally — no need to focus the navigation host first.</li>
+    </ul>
+
+    <h3 id="ctrl-arrow-api">API</h3>
+    <table class="table">
+      <thead>
+        <tr>
+          <th class="left">Input</th>
+          <th class="left clr-hidden-xs-down">Type</th>
+          <th class="clr-hidden-xs-down">Default</th>
+          <th class="left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="left"><code class="clr-code">clrNavItemSelector</code></td>
+          <td class="left clr-hidden-xs-down">string</td>
+          <td class="clr-hidden-xs-down"><code class="clr-code">[clrVerticalNavLink], [clrTabLink]</code></td>
+          <td class="left">CSS selector for the navigable items inside the host element.</td>
+        </tr>
+        <tr>
+          <td class="left"><code class="clr-code">clrNavOrientation</code></td>
+          <td class="left clr-hidden-xs-down"><code class="clr-code">'horizontal' | 'vertical' | 'both'</code></td>
+          <td class="clr-hidden-xs-down"><code class="clr-code">'both'</code></td>
+          <td class="left">
+            Restricts which arrow directions are active. Use <code class="clr-code">'horizontal'</code> for tabs,
+            <code class="clr-code">'vertical'</code> for sidebars.
+          </td>
+        </tr>
+        <tr>
+          <td class="left"><code class="clr-code">clrNavDisabled</code></td>
+          <td class="left clr-hidden-xs-down">boolean</td>
+          <td class="clr-hidden-xs-down"><code class="clr-code">false</code></td>
+          <td class="left">
+            Set to <code class="clr-code">true</code> to disable all navigation (e.g. while a modal is open).
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 id="ctrl-arrow-demo">Interactive Demo</h3>
+    <p>
+      Press <kbd>Ctrl+Right</kbd> / <kbd>Ctrl+Left</kbd> anywhere on the page to cycle through the tabs below.
+      Navigation wraps around — <kbd>Ctrl+Left</kbd> on Category 1 jumps to the last tab.
+    </p>
+
+    <div class="clr-example">
+      <clr-tabs clrKeyboardNavCtrlArrow clrNavOrientation="horizontal">
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="home"></cds-icon> Category 1</button>
+          <clr-tab-content *clrIfActive="true">
+            <div style="padding: 1rem">
+              <strong>Category 1</strong> — Press <kbd>Ctrl+Right</kbd> to go forward. <kbd>Ctrl+Left</kbd> from here
+              wraps to the last tab.
+            </div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="cog"></cds-icon> Category 2</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Category 2</strong></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="user"></cds-icon> Category 3</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Category 3</strong></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="bell"></cds-icon> Category 4</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem">
+              <strong>Category 4</strong> — <kbd>Ctrl+Right</kbd> wraps back to Category 1.
+            </div>
+          </clr-tab-content>
+        </clr-tab>
+      </clr-tabs>
+    </div>
+
+    <h3 id="ctrl-arrow-example">Code Example</h3>
+    <clr-code-snippet [clrCode]="ctrlArrowExample"></clr-code-snippet>
+
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         2. Alt+Mnemonic
+    ════════════════════════════════════════════════════════════════════════ -->
+    <h2 id="alt-mnemonic">clrKeyboardNavAltMnemonic</h2>
+    <p>
+      Assigns sequential numeric mnemonics (1, 2, 3, …) to navigation items and enables
+      <kbd>Alt</kbd>-key-based navigation.
+    </p>
+    <ul>
+      <li>Mnemonics are assigned once at view initialisation and remain stable for the page lifetime.</li>
+      <li>
+        While <kbd>Alt</kbd> is held the CSS class <code class="clr-code">clr-kbd-mnemonics-visible</code> is added to
+        the host — styled badges appear on each item.
+      </li>
+      <li>Digit keys pressed while <kbd>Alt</kbd> is held accumulate into a buffer.</li>
+      <li>
+        Releasing <kbd>Alt</kbd> navigates to the matching item. Multi-digit mnemonics are supported: <kbd>Alt</kbd> +
+        <kbd>1</kbd> + <kbd>0</kbd> → item 10.
+      </li>
+      <li>
+        When an item has a <code class="clr-code">cds-icon</code>, the icon is replaced <em>in-place</em> by a circle
+        badge while <kbd>Alt</kbd> is held — no layout shift.
+      </li>
+      <li><kbd>Alt+Arrow</kbd> browser history navigation is never overridden.</li>
+    </ul>
+
+    <h3 id="alt-mnemonic-api">API</h3>
+    <table class="table">
+      <thead>
+        <tr>
+          <th class="left">Input</th>
+          <th class="left clr-hidden-xs-down">Type</th>
+          <th class="clr-hidden-xs-down">Default</th>
+          <th class="left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="left"><code class="clr-code">clrNavItemSelector</code></td>
+          <td class="left clr-hidden-xs-down">string</td>
+          <td class="clr-hidden-xs-down"><code class="clr-code">[clrVerticalNavLink], [clrTabLink]</code></td>
+          <td class="left">CSS selector for the navigable items inside the host element.</td>
+        </tr>
+        <tr>
+          <td class="left"><code class="clr-code">clrNavDisabled</code></td>
+          <td class="left clr-hidden-xs-down">boolean</td>
+          <td class="clr-hidden-xs-down"><code class="clr-code">false</code></td>
+          <td class="left">
+            Set to <code class="clr-code">true</code> to disable all navigation (e.g. while a modal is open).
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 id="alt-mnemonic-tabs-demo">Demo — Tabs (11 items, multi-digit mnemonic)</h3>
+    <p>
+      Hold <kbd>Alt</kbd> to reveal the numbered badges, then type a digit (or two) to navigate. Items 10 and 11 require
+      two keystrokes: <kbd>Alt</kbd> + <kbd>1</kbd> + <kbd>0</kbd> and <kbd>Alt</kbd> + <kbd>1</kbd> + <kbd>1</kbd>.
+    </p>
+
+    <div class="clr-example">
+      <clr-tabs clrKeyboardNavAltMnemonic>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="star"></cds-icon> Alpha</button>
+          <clr-tab-content *clrIfActive="true">
+            <div style="padding: 1rem"><strong>Alpha</strong> — mnemonic <kbd>Alt+1</kbd></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="heart"></cds-icon> Beta</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Beta</strong> — mnemonic <kbd>Alt+2</kbd></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="bolt"></cds-icon> Gamma</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Gamma</strong> — mnemonic <kbd>Alt+3</kbd></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="flag"></cds-icon> Delta</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Delta</strong> — mnemonic <kbd>Alt+4</kbd></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="search"></cds-icon> Epsilon</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Epsilon</strong> — mnemonic <kbd>Alt+5</kbd></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="folder"></cds-icon> Zeta</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Zeta</strong> — mnemonic <kbd>Alt+6</kbd></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="calendar"></cds-icon> Eta</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Eta</strong> — mnemonic <kbd>Alt+7</kbd></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="map"></cds-icon> Theta</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Theta</strong> — mnemonic <kbd>Alt+8</kbd></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="terminal"></cds-icon> Iota</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Iota</strong> — mnemonic <kbd>Alt+9</kbd></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="shield"></cds-icon> Kappa</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem">
+              <strong>Kappa</strong> — two-digit mnemonic <kbd>Alt</kbd>+<kbd>1</kbd><kbd>0</kbd>
+            </div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="clock"></cds-icon> Lambda</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem">
+              <strong>Lambda</strong> — two-digit mnemonic <kbd>Alt</kbd>+<kbd>1</kbd><kbd>1</kbd>
+            </div>
+          </clr-tab-content>
+        </clr-tab>
+      </clr-tabs>
+    </div>
+
+    <h3 id="alt-mnemonic-vertical-demo">Demo — Vertical Nav with Icons</h3>
+    <p>
+      The <code class="clr-code">cds-icon</code> in front of each label is replaced <em>in-place</em> by the circle
+      badge when <kbd>Alt</kbd> is held — no layout shift occurs. Active item:
+      <strong>{{ activeVerticalNavItem }}</strong>
+    </p>
+
+    <div class="clr-example" style="max-width: 220px">
+      <clr-vertical-nav clrKeyboardNavAltMnemonic>
+        <a
+          clrVerticalNavLink
+          href="#"
+          [class.active]="activeVerticalNavItem === 'Home'"
+          (click)="activeVerticalNavItem = 'Home'; $event.preventDefault()"
+        >
+          <cds-icon clrVerticalNavIcon shape="home"></cds-icon>
+          Home
+        </a>
+        <a
+          clrVerticalNavLink
+          href="#"
+          [class.active]="activeVerticalNavItem === 'Search'"
+          (click)="activeVerticalNavItem = 'Search'; $event.preventDefault()"
+        >
+          <cds-icon clrVerticalNavIcon shape="search"></cds-icon>
+          Search
+        </a>
+        <a
+          clrVerticalNavLink
+          href="#"
+          [class.active]="activeVerticalNavItem === 'Profile'"
+          (click)="activeVerticalNavItem = 'Profile'; $event.preventDefault()"
+        >
+          <cds-icon clrVerticalNavIcon shape="user"></cds-icon>
+          Profile
+        </a>
+        <a
+          clrVerticalNavLink
+          href="#"
+          [class.active]="activeVerticalNavItem === 'Documents'"
+          (click)="activeVerticalNavItem = 'Documents'; $event.preventDefault()"
+        >
+          <cds-icon clrVerticalNavIcon shape="folder"></cds-icon>
+          Documents
+        </a>
+        <a
+          clrVerticalNavLink
+          href="#"
+          [class.active]="activeVerticalNavItem === 'Notifications'"
+          (click)="activeVerticalNavItem = 'Notifications'; $event.preventDefault()"
+        >
+          <cds-icon clrVerticalNavIcon shape="bell"></cds-icon>
+          Notifications
+        </a>
+        <a
+          clrVerticalNavLink
+          href="#"
+          [class.active]="activeVerticalNavItem === 'Settings'"
+          (click)="activeVerticalNavItem = 'Settings'; $event.preventDefault()"
+        >
+          <cds-icon clrVerticalNavIcon shape="cog"></cds-icon>
+          Settings
+        </a>
+      </clr-vertical-nav>
+    </div>
+
+    <h3 id="alt-mnemonic-example">Code Example</h3>
+    <clr-code-snippet [clrCode]="altMnemonicExample"></clr-code-snippet>
+
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         3. Both combined
+    ════════════════════════════════════════════════════════════════════════ -->
+    <h2 id="combined">Both Directives Combined</h2>
+    <p>
+      Both directives can be applied to the same host element. Use either
+      <kbd>Ctrl+Arrow</kbd> or <kbd>Alt+digit</kbd> to navigate — they operate independently and never interfere with
+      each other.
+    </p>
+    <p>
+      The shared <code class="clr-code">[clrNavDisabled]</code> input deactivates <em>both</em> shortcuts at once when
+      set to <code class="clr-code">true</code>, making it easy to guard against navigation while a modal or overlay is
+      open.
+    </p>
+
+    <h3 id="combined-demo">Interactive Demo — Overlay Guard</h3>
+    <p>Check the checkbox to simulate an active overlay. Both shortcuts are suspended while it is checked.</p>
+
+    <div class="clr-example">
+      <label style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem">
+        <input type="checkbox" [(ngModel)]="overlayActive" />
+        Simulate overlay active (<code class="clr-code">[clrNavDisabled]="overlayActive"</code>)
+      </label>
+
+      <clr-tabs
+        clrKeyboardNavCtrlArrow
+        clrKeyboardNavAltMnemonic
+        clrNavOrientation="horizontal"
+        [clrNavDisabled]="overlayActive"
+      >
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="wrench"></cds-icon> Service</button>
+          <clr-tab-content *clrIfActive="true">
+            <div style="padding: 1rem">
+              <strong>Service</strong> — <kbd>Alt+1</kbd> / <kbd>Ctrl+Left</kbd> or <kbd>Ctrl+Right</kbd>
+            </div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="blocks-group"></cds-icon> Parts</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Parts</strong> — <kbd>Alt+2</kbd></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="inbox"></cds-icon> Package</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Package</strong> — <kbd>Alt+3</kbd></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="drop"></cds-icon> Fluid</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Fluid</strong> — <kbd>Alt+4</kbd></div>
+          </clr-tab-content>
+        </clr-tab>
+        <clr-tab>
+          <button clrTabLink><cds-icon shape="circle"></cds-icon> Tyres</button>
+          <clr-tab-content *clrIfActive>
+            <div style="padding: 1rem"><strong>Tyres</strong> — <kbd>Alt+5</kbd></div>
+          </clr-tab-content>
+        </clr-tab>
+      </clr-tabs>
+    </div>
+
+    <h3 id="combined-example">Code Example</h3>
+    <clr-code-snippet [clrCode]="combinedExample"></clr-code-snippet>
+
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         4. Best Practices
+    ════════════════════════════════════════════════════════════════════════ -->
+    <h2 id="best-practices">Best Practices</h2>
+    <ul>
+      <li>
+        Always set <code class="clr-code">clrNavOrientation="horizontal"</code> on
+        <code class="clr-code">clr-tabs</code> to avoid conflicting with vertical shortcuts.
+      </li>
+      <li>
+        Bind <code class="clr-code">[clrNavDisabled]</code> to your overlay/modal open state to prevent accidental
+        navigation while dialogs are open.
+      </li>
+      <li>
+        Both directives work with any focusable host element — not just Clarity components. Use
+        <code class="clr-code">clrNavItemSelector</code> to target custom nav buttons.
+      </li>
+      <li>
+        The <code class="clr-code">clrKeyboardNavAltMnemonic</code> directive never overrides <kbd>Alt+Arrow</kbd>,
+        preserving browser history navigation.
+      </li>
+      <li>
+        Mnemonics remain stable across the page lifetime. If items are added dynamically after initialisation,
+        reinitialise the component to reassign mnemonics.
+      </li>
+    </ul>
+  </article>
+</clr-doc-wrapper>
+
+<!-- ─── ToC template ───────────────────────────────────────────────────────── -->
+<ng-template #tocList let-entries>
+  @if (entries?.length) {
+  <ul class="list-unstyled toc-list">
+    @for (entry of entries; track entry) {
+    <li>
+      <a
+        [fragment]="entry.id"
+        [class.active]="(activeFragment | async) === entry.id"
+        [replaceUrl]="true"
+        routerLink="."
+      >
+        {{ entry.label }}
+      </a>
+      <ng-container *ngTemplateOutlet="tocList; context: { $implicit: entry.children }"></ng-container>
+    </li>
+    }
+  </ul>
+  }
+</ng-template>

--- a/website/src/app/documentation/demos/keyboard-nav/keyboard-nav.demo.module.ts
+++ b/website/src/app/documentation/demos/keyboard-nav/keyboard-nav.demo.module.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { ClarityModule } from '@clr/angular';
+import {
+  ClrAddonsModule,
+  ClrKeyboardNavCtrlArrowDirective,
+  ClrKeyboardNavAltMnemonicDirective,
+} from '@porscheinformatik/clr-addons';
+import { UtilsModule } from '../../../utils/utils.module';
+import { DocWrapperModule } from '../_doc-wrapper/doc-wrapper.module';
+import { KeyboardNavDemo } from './keyboard-nav.demo';
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    ClarityModule,
+    ClrAddonsModule,
+    ClrKeyboardNavCtrlArrowDirective,
+    ClrKeyboardNavAltMnemonicDirective,
+    UtilsModule,
+    DocWrapperModule,
+    RouterModule.forChild([{ path: '', component: KeyboardNavDemo }]),
+  ],
+  declarations: [KeyboardNavDemo],
+  exports: [KeyboardNavDemo],
+})
+export class KeyboardNavDemoModule {}

--- a/website/src/app/documentation/demos/keyboard-nav/keyboard-nav.demo.ts
+++ b/website/src/app/documentation/demos/keyboard-nav/keyboard-nav.demo.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Component, ElementRef, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { share } from 'rxjs';
+import { ClarityDocComponent } from '../clarity-doc';
+import { ClarityIcons, homeIcon, cogIcon, userIcon, searchIcon, folderIcon, bellIcon } from '@cds/core/icon';
+import {
+  CTRL_ARROW_BASIC_EXAMPLE,
+  ALT_MNEMONIC_BASIC_EXAMPLE,
+  COMBINED_EXAMPLE,
+  IMPORT_EXAMPLE,
+} from './keyboard-nav-examples.demo';
+
+ClarityIcons.addIcons(homeIcon, cogIcon, userIcon, searchIcon, folderIcon, bellIcon);
+
+export interface TocEntry {
+  id: string;
+  label: string;
+  children?: TocEntry[];
+}
+
+@Component({
+  selector: 'clr-keyboard-nav-demo',
+  templateUrl: './keyboard-nav.demo.html',
+  host: {
+    '[class.content-area]': 'true',
+    '[class.dox-content-panel]': 'true',
+  },
+  standalone: false,
+})
+export class KeyboardNavDemo extends ClarityDocComponent implements OnInit {
+  ctrlArrowExample = CTRL_ARROW_BASIC_EXAMPLE;
+  altMnemonicExample = ALT_MNEMONIC_BASIC_EXAMPLE;
+  combinedExample = COMBINED_EXAMPLE;
+  importExample = IMPORT_EXAMPLE;
+
+  overlayActive = false;
+  activeVerticalNavItem = 'Home';
+
+  protected activeFragment;
+  tableOfContents: TocEntry[] = [];
+
+  private headingSelector = 'h2[id],h3[id]';
+
+  constructor(public route: ActivatedRoute, private elementRef: ElementRef) {
+    super('keyboard-nav');
+    this.activeFragment = this.route.fragment.pipe(share());
+  }
+
+  ngOnInit(): void {
+    const headings = Array.from(
+      this.elementRef.nativeElement.querySelectorAll(this.headingSelector)
+    ) as HTMLHeadingElement[];
+    this.tableOfContents = this.buildToc(headings);
+  }
+
+  private buildToc(headings: HTMLHeadingElement[]): TocEntry[] {
+    const entries: TocEntry[] = [];
+    for (const h of headings) {
+      if (h.tagName === 'H2') {
+        entries.push({ id: h.id, label: h.innerText, children: [] });
+      } else if (h.tagName === 'H3' && entries.length) {
+        entries[entries.length - 1].children!.push({ id: h.id, label: h.innerText });
+      }
+    }
+    return entries;
+  }
+}

--- a/website/src/app/documentation/documentation-routing.module.ts
+++ b/website/src/app/documentation/documentation-routing.module.ts
@@ -280,6 +280,13 @@ const documentationRoutes: Routes = [
           browserTitle: 'Control Warning',
         },
       },
+      {
+        path: 'keyboard-nav',
+        loadChildren: () => import('./demos/keyboard-nav/keyboard-nav.demo.module').then(m => m.KeyboardNavDemoModule),
+        data: {
+          browserTitle: 'Keyboard Navigation',
+        },
+      },
     ],
   },
 ];

--- a/website/src/settings/componentlist.json
+++ b/website/src/settings/componentlist.json
@@ -86,6 +86,11 @@
       "type": "component"
     },
     {
+      "url": "keyboard-nav",
+      "text": "Keyboard Navigation",
+      "type": "component"
+    },
+    {
       "url": "letter-avatar",
       "text": "Letter avatar",
       "type": "component"


### PR DESCRIPTION
This pull request introduces two new keyboard navigation directives for "command + arrowKey" and "alt + NrKey". The changes include the implementation of the directives, their integration into the module, the addition of supporting SCSS styles, and updates to exports and routing for demo purposes.