### PR TITLE
C3DEV-583431 Copy to Clipboard component fix

### DIFF
--- a/src/clr-addons/copy-to-clipboard/copy-to-clipboard.html
+++ b/src/clr-addons/copy-to-clipboard/copy-to-clipboard.html
@@ -8,6 +8,7 @@
     [ngClass]="{ 'attribute-was-copied-color': showCopiedIcon }"
     (click)="$event.stopPropagation()"
     (keydown.enter)="$event.stopPropagation()"
+    (mousedown)="$event.preventDefault()"
   ></cds-icon>
   <clr-tooltip-content [clrSize]="tooltipSize" [clrPosition]="tooltipPosition" *clrIfOpen
     >{{ tooltipText() }}</clr-tooltip-content


### PR DESCRIPTION
Prevent jumping of tooltip bubble on click. When trying to use the copy to clipboard component in service base, the tooltip bubble always jumped below its initial position. i assume it has something to do with the focusing on the icon, what is triggering it.