### PR TITLE
add width: fit-content

### DIFF
--- a/src/clr-addons/copy-to-clipboard/copy-to-clipboard.scss
+++ b/src/clr-addons/copy-to-clipboard/copy-to-clipboard.scss
@@ -35,3 +35,7 @@
   align-items: center;
   gap: 0.25rem;
 }
+
+clr-tooltip-content {
+  width: fit-content;
+}


### PR DESCRIPTION
so the tooltip box adjusts its width according to the size of the text inside.
Currently there is a lot of space left in the box if the text is short

Current  behaviour:
<img width="348" height="106" alt="grafik" src="https://github.com/user-attachments/assets/94e4b374-0035-4e29-85dc-950b41ed0dae" />

After the change:
<img width="284" height="110" alt="grafik" src="https://github.com/user-attachments/assets/5b9361a5-da10-4296-8d3e-5a5c8cbef054" />
