### PR TITLE
Add new image gallery component

### DIFF
--- a/src/clr-addons/clr-addons.module.ts
+++ b/src/clr-addons/clr-addons.module.ts
@@ -48,6 +48,7 @@ import { ClrControlEnterSubmitDirective } from './control-enter-submit';
 import { ClrSignpostAddonModule } from './signpost';
 import { ClrKeyboardNavCtrlArrowDirective } from './keyboard-nav/clr-keyboard-nav-ctrl-arrow.directive';
 import { ClrKeyboardNavAltMnemonicDirective } from './keyboard-nav/clr-keyboard-nav-alt-mnemonic.directive';
+import { ClrImageGalleryModule } from './image-gallery';
 
 @NgModule({
   imports: [
@@ -99,6 +100,7 @@ import { ClrKeyboardNavAltMnemonicDirective } from './keyboard-nav/clr-keyboard-
     ClrControlEnterSubmitDirective,
     ClrKeyboardNavCtrlArrowDirective,
     ClrKeyboardNavAltMnemonicDirective,
+    ClrImageGalleryModule,
   ],
 })
 export class ClrAddonsModule {}

--- a/src/clr-addons/image-gallery/image-carousel.html
+++ b/src/clr-addons/image-gallery/image-carousel.html
@@ -1,0 +1,51 @@
+<!--
+  ~ Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<div class="clr-image-carousel">
+  <!-- Header -->
+  <div class="clr-image-carousel__header" *ngIf="!hideHeader()">
+    <span class="clr-image-carousel__title">{{ productName() }}</span>
+    <button class="clr-image-carousel__close" (click)="closeCarousel.emit()" aria-label="Close">
+      <cds-icon shape="times"></cds-icon>
+    </button>
+  </div>
+
+  <!-- Spotlight -->
+  <div class="clr-image-carousel__spotlight">
+    <div class="clr-image-carousel__img-wrap">
+      <button class="clr-image-carousel__arrow clr-image-carousel__arrow--prev" (click)="prev()" aria-label="Previous">
+        <cds-icon shape="circle-arrow" direction="left" solid></cds-icon>
+      </button>
+
+      <img
+        *ngIf="images().length > 0"
+        [src]="images()[activeIndex()].src"
+        [alt]="images()[activeIndex()].alt || ''"
+        class="clr-image-carousel__img"
+      />
+
+      <button class="clr-image-carousel__arrow clr-image-carousel__arrow--next" (click)="next()" aria-label="Next">
+        <cds-icon shape="circle-arrow" direction="right" solid></cds-icon>
+      </button>
+    </div>
+  </div>
+
+  <!-- Thumbnail strip -->
+  <div class="clr-image-carousel__thumbs-wrap">
+    <div class="clr-image-carousel__thumbs" #thumbStrip>
+      <span class="clr-image-carousel__thumbs-spacer" [style.width.px]="spacerWidth()"></span>
+      <div
+        *ngFor="let img of images(); let i = index"
+        class="clr-image-carousel__thumb"
+        [class.clr-image-carousel__thumb--active]="i === activeIndex()"
+        (click)="setActive(i)"
+      >
+        <img [src]="img.src" [alt]="img.alt || ''" class="clr-image-carousel__thumb-img" />
+      </div>
+      <span class="clr-image-carousel__thumbs-spacer" [style.width.px]="spacerWidth()"></span>
+    </div>
+  </div>
+</div>

--- a/src/clr-addons/image-gallery/image-carousel.html
+++ b/src/clr-addons/image-gallery/image-carousel.html
@@ -13,39 +13,59 @@
     </button>
   </div>
 
-  <!-- Spotlight -->
-  <div class="clr-image-carousel__spotlight">
-    <div class="clr-image-carousel__img-wrap">
-      <button class="clr-image-carousel__arrow clr-image-carousel__arrow--prev" (click)="prev()" aria-label="Previous">
-        <cds-icon shape="circle-arrow" direction="left" solid></cds-icon>
-      </button>
-
-      <img
-        *ngIf="images().length > 0"
-        [src]="images()[activeIndex()].src"
-        [alt]="images()[activeIndex()].alt || ''"
-        class="clr-image-carousel__img"
-      />
-
-      <button class="clr-image-carousel__arrow clr-image-carousel__arrow--next" (click)="next()" aria-label="Next">
-        <cds-icon shape="circle-arrow" direction="right" solid></cds-icon>
-      </button>
-    </div>
-  </div>
-
-  <!-- Thumbnail strip -->
-  <div class="clr-image-carousel__thumbs-wrap">
-    <div class="clr-image-carousel__thumbs" #thumbStrip>
-      <span class="clr-image-carousel__thumbs-spacer" [style.width.px]="spacerWidth()"></span>
+  <!-- Spotlight + thumbnails, constrained to image width -->
+  <div class="clr-image-carousel__content" [style.width.px]="imageSize() > 0 ? imageSize() : null">
+    <!-- Spotlight -->
+    <div class="clr-image-carousel__spotlight">
       <div
-        *ngFor="let img of images(); let i = index"
-        class="clr-image-carousel__thumb"
-        [class.clr-image-carousel__thumb--active]="i === activeIndex()"
-        (click)="setActive(i)"
+        class="clr-image-carousel__img-wrap"
+        [style.width.px]="imageSize() > 0 ? imageSize() : null"
+        [style.height.px]="imageSize() > 0 ? imageSize() : null"
       >
-        <img [src]="img.src" [alt]="img.alt || ''" class="clr-image-carousel__thumb-img" />
+        <button
+          class="clr-image-carousel__arrow clr-image-carousel__arrow--prev"
+          (click)="prev()"
+          aria-label="Previous"
+        >
+          <cds-icon shape="circle-arrow" direction="left" solid></cds-icon>
+        </button>
+
+        <img
+          *ngIf="images().length > 0"
+          [src]="images()[activeIndex()].src"
+          [alt]="images()[activeIndex()].alt || ''"
+          class="clr-image-carousel__img"
+        />
+
+        <button class="clr-image-carousel__arrow clr-image-carousel__arrow--next" (click)="next()" aria-label="Next">
+          <cds-icon shape="circle-arrow" direction="right" solid></cds-icon>
+        </button>
       </div>
-      <span class="clr-image-carousel__thumbs-spacer" [style.width.px]="spacerWidth()"></span>
+    </div>
+
+    <!-- Thumbnail strip -->
+    <div
+      class="clr-image-carousel__thumbs-wrap"
+      [class.clr-image-carousel__thumbs-wrap--fade-left]="showFadeLeft()"
+      [class.clr-image-carousel__thumbs-wrap--fade-right]="showFadeRight()"
+    >
+      <div
+        class="clr-image-carousel__thumbs"
+        [class.clr-image-carousel__thumbs--centered]="!needsScroll()"
+        (scroll)="onThumbStripScroll()"
+        #thumbStrip
+      >
+        <div
+          *ngFor="let img of images(); let i = index"
+          class="clr-image-carousel__thumb"
+          [style.width.px]="thumbnailSize()"
+          [style.height.px]="thumbnailSize()"
+          [class.clr-image-carousel__thumb--active]="i === activeIndex()"
+          (click)="setActive(i)"
+        >
+          <img [src]="img.src" [alt]="img.alt || ''" class="clr-image-carousel__thumb-img" />
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/clr-addons/image-gallery/image-carousel.scss
+++ b/src/clr-addons/image-gallery/image-carousel.scss
@@ -19,10 +19,6 @@ $carousel-img-to-thumbs: 8px;
 $carousel-bottom-pad: $carousel-pad;
 $carousel-thumb-row-h: $carousel-img-to-thumbs + $carousel-thumb-size + $carousel-bottom-pad; // 96px
 
-// Image side used only in the built-in full-screen modal (96vh context).
-// When embedded inside a parent modal the spotlight stretches via flex instead.
-$carousel-img-side-fullscreen: calc(96vh - #{$carousel-header-h} - #{$carousel-thumb-row-h});
-
 .clr-image-carousel {
   display: flex;
   flex-direction: column;

--- a/src/clr-addons/image-gallery/image-carousel.scss
+++ b/src/clr-addons/image-gallery/image-carousel.scss
@@ -26,8 +26,10 @@ $carousel-img-side-fullscreen: calc(96vh - #{$carousel-header-h} - #{$carousel-t
 .clr-image-carousel {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  padding: 0 $carousel-pad;
+  box-sizing: border-box;
   width: 100%;
-  height: 100%;
   background: var(--clr-modal-bg-color, #fff);
   overflow: hidden;
 
@@ -36,9 +38,9 @@ $carousel-img-side-fullscreen: calc(96vh - #{$carousel-header-h} - #{$carousel-t
     align-items: center;
     justify-content: space-between;
     height: $carousel-header-h;
-    padding: 0 $carousel-pad;
     flex-shrink: 0;
     box-sizing: border-box;
+    align-self: stretch;
   }
 
   &__title {
@@ -68,10 +70,16 @@ $carousel-img-side-fullscreen: calc(96vh - #{$carousel-header-h} - #{$carousel-t
     }
   }
 
+  &__content {
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+    // Fills container in auto mode; overridden by inline style when imageSize > 0
+    width: 100%;
+  }
+
   &__spotlight {
-    flex: 1 1 auto;
-    min-height: 0;
-    padding: 0 $carousel-pad;
+    flex-shrink: 0;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -79,9 +87,9 @@ $carousel-img-side-fullscreen: calc(96vh - #{$carousel-header-h} - #{$carousel-t
 
   &__img-wrap {
     position: relative;
+    // Fills content width in auto mode; overridden by inline style when imageSize > 0
+    width: 100%;
     aspect-ratio: 1;
-    height: 100%;
-    max-width: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -138,6 +146,8 @@ $carousel-img-side-fullscreen: calc(96vh - #{$carousel-header-h} - #{$carousel-t
   &__thumbs-wrap {
     position: relative;
     flex-shrink: 0;
+    width: 100%;
+    overflow: hidden;
 
     &::before,
     &::after {
@@ -148,6 +158,8 @@ $carousel-img-side-fullscreen: calc(96vh - #{$carousel-header-h} - #{$carousel-t
       width: 48px;
       z-index: 1;
       pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s;
     }
 
     &::before {
@@ -159,6 +171,14 @@ $carousel-img-side-fullscreen: calc(96vh - #{$carousel-header-h} - #{$carousel-t
       right: 0;
       background: linear-gradient(to left, var(--clr-modal-bg-color, #fff), transparent);
     }
+
+    &--fade-left::before {
+      opacity: 1;
+    }
+
+    &--fade-right::after {
+      opacity: 1;
+    }
   }
 
   &__thumbs {
@@ -167,11 +187,19 @@ $carousel-img-side-fullscreen: calc(96vh - #{$carousel-header-h} - #{$carousel-t
     padding: $carousel-img-to-thumbs 0 $carousel-bottom-pad 0;
     overflow-x: auto;
     flex-shrink: 0;
+    width: 100%;
+    box-sizing: border-box;
     scroll-behavior: smooth;
     scrollbar-width: none;
 
     &::-webkit-scrollbar {
       display: none;
+    }
+
+    // When all thumbnails fit, center them statically without scrolling
+    &--centered {
+      justify-content: center;
+      overflow-x: hidden;
     }
   }
 
@@ -180,8 +208,7 @@ $carousel-img-side-fullscreen: calc(96vh - #{$carousel-header-h} - #{$carousel-t
   }
 
   &__thumb {
-    width: $carousel-thumb-size;
-    height: $carousel-thumb-size;
+    // width/height set via inline style from thumbnailSize() input (default 64px)
     flex-shrink: 0;
     overflow: hidden;
     cursor: pointer;

--- a/src/clr-addons/image-gallery/image-carousel.scss
+++ b/src/clr-addons/image-gallery/image-carousel.scss
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+// ─── Carousel (inner content, no backdrop) ───────────────────────────────────
+// Dimensions match the built-in modal context (96vh tall, image fills remaining
+// space). When embedded inside a parent modal the host element should stretch to
+// fill available space; the carousel is a flex column that self-sizes.
+//
+// Sizing variables mirror image-gallery.scss so the two contexts look identical.
+
+$carousel-pad: 24px;
+$carousel-header-h: 68px;
+$carousel-thumb-size: 64px;
+$carousel-thumb-gap: 8px;
+$carousel-img-to-thumbs: 8px;
+$carousel-bottom-pad: $carousel-pad;
+$carousel-thumb-row-h: $carousel-img-to-thumbs + $carousel-thumb-size + $carousel-bottom-pad; // 96px
+
+// Image side used only in the built-in full-screen modal (96vh context).
+// When embedded inside a parent modal the spotlight stretches via flex instead.
+$carousel-img-side-fullscreen: calc(96vh - #{$carousel-header-h} - #{$carousel-thumb-row-h});
+
+.clr-image-carousel {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: var(--clr-modal-bg-color, #fff);
+  overflow: hidden;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: $carousel-header-h;
+    padding: 0 $carousel-pad;
+    flex-shrink: 0;
+    box-sizing: border-box;
+  }
+
+  &__title {
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 24px;
+  }
+
+  &__close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: inherit;
+
+    cds-icon {
+      --color: currentColor;
+      width: 18px;
+      height: 18px;
+    }
+
+    &:hover {
+      opacity: 0.7;
+    }
+  }
+
+  &__spotlight {
+    flex: 1 1 auto;
+    min-height: 0;
+    padding: 0 $carousel-pad;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__img-wrap {
+    position: relative;
+    aspect-ratio: 1;
+    height: 100%;
+    max-width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    border-radius: 3px;
+  }
+
+  &__img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  &__arrow {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 1;
+    background: none;
+    border: none;
+    padding: 0;
+    outline: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    opacity: 0.25;
+    transition: opacity 0.15s;
+
+    &:focus {
+      outline: none;
+    }
+
+    &:hover {
+      opacity: 1;
+    }
+
+    &--prev {
+      left: 12px;
+    }
+
+    &--next {
+      right: 12px;
+    }
+
+    cds-icon {
+      --color: white;
+      width: 56px;
+      height: 56px;
+    }
+  }
+
+  &__thumbs-wrap {
+    position: relative;
+    flex-shrink: 0;
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 48px;
+      z-index: 1;
+      pointer-events: none;
+    }
+
+    &::before {
+      left: 0;
+      background: linear-gradient(to right, var(--clr-modal-bg-color, #fff), transparent);
+    }
+
+    &::after {
+      right: 0;
+      background: linear-gradient(to left, var(--clr-modal-bg-color, #fff), transparent);
+    }
+  }
+
+  &__thumbs {
+    display: flex;
+    gap: $carousel-thumb-gap;
+    padding: $carousel-img-to-thumbs 0 $carousel-bottom-pad 0;
+    overflow-x: auto;
+    flex-shrink: 0;
+    scroll-behavior: smooth;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  &__thumbs-spacer {
+    flex-shrink: 0;
+  }
+
+  &__thumb {
+    width: $carousel-thumb-size;
+    height: $carousel-thumb-size;
+    flex-shrink: 0;
+    overflow: hidden;
+    cursor: pointer;
+    border-radius: 3px;
+    outline: 4px solid transparent;
+    outline-offset: -4px;
+    transition: outline-color 0.15s;
+
+    &--active {
+      outline-color: #14a1a9;
+    }
+
+    &:hover:not(&--active) {
+      outline-color: var(--clr-color-neutral-400, #aaa);
+    }
+  }
+
+  &__thumb-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}

--- a/src/clr-addons/image-gallery/image-carousel.ts
+++ b/src/clr-addons/image-gallery/image-carousel.ts
@@ -24,16 +24,25 @@ export class ClrImageCarousel {
   readonly initialIndex = input(0);
   /** When true the header row (title + close button) is not rendered. */
   readonly hideHeader = input(false);
+  /**
+   * Size in pixels of the active (spotlight) image square.
+   * When 0 (default), the image fills the available container width automatically.
+   */
+  readonly imageSize = input(0);
+  /**
+   * Size in pixels of each thumbnail square.
+   * Defaults to 64px.
+   */
+  readonly thumbnailSize = input(64);
 
   readonly closeCarousel = output<void>();
 
   protected activeIndex = signal(0);
-  protected spacerWidth = signal(0);
-
-  private readonly thumbPx = 64;
+  protected needsScroll = signal(false);
+  protected showFadeLeft = signal(false);
+  protected showFadeRight = signal(false);
 
   constructor() {
-    // Seed activeIndex from initialIndex whenever it changes
     effect(() => {
       this.activeIndex.set(this.initialIndex());
     });
@@ -41,36 +50,57 @@ export class ClrImageCarousel {
     effect(() => {
       const index = this.activeIndex();
       setTimeout(() => {
-        this.updateSpacerWidth();
+        this.updateScrollState();
         this.scrollThumbIntoCenter(index);
       });
     });
   }
 
-  private updateSpacerWidth(): void {
+  private updateScrollState(): void {
     const strip = this.thumbStripRef?.nativeElement;
     if (!strip) {
       return;
     }
-    this.spacerWidth.set(Math.max(0, strip.clientWidth / 2 - this.thumbPx / 2));
+    const thumbCount = this.images().length;
+    const gap = 8;
+    const contentWidth = thumbCount * this.thumbnailSize() + Math.max(0, thumbCount - 1) * gap;
+    this.needsScroll.set(contentWidth > strip.clientWidth);
+    this.updateFades(strip);
+  }
+
+  protected onThumbStripScroll(): void {
+    const strip = this.thumbStripRef?.nativeElement;
+    if (strip) {
+      this.updateFades(strip);
+    }
+  }
+
+  private updateFades(strip: HTMLElement): void {
+    const atLeft = strip.scrollLeft <= 0;
+    const atRight = strip.scrollLeft >= strip.scrollWidth - strip.clientWidth - 1;
+    this.showFadeLeft.set(this.needsScroll() && !atLeft);
+    this.showFadeRight.set(this.needsScroll() && !atRight);
   }
 
   private scrollThumbIntoCenter(index: number): void {
     const strip = this.thumbStripRef?.nativeElement;
-    if (!strip) {
+    if (!strip || !this.needsScroll()) {
       return;
     }
-    const thumb = strip.children[index + 1] as HTMLElement | undefined;
+    const thumb = strip.children[index] as HTMLElement | undefined;
     if (!thumb) {
       return;
     }
     const stripRect = strip.getBoundingClientRect();
     const thumbRect = thumb.getBoundingClientRect();
-    const thumbCenterRelativeToStrip = thumbRect.left - stripRect.left + thumbRect.width / 2 + strip.scrollLeft;
+    const thumbCenterInScroll = thumbRect.left - stripRect.left + thumbRect.width / 2 + strip.scrollLeft;
+    const desired = thumbCenterInScroll - strip.clientWidth / 2;
+    const maxScroll = strip.scrollWidth - strip.clientWidth;
     strip.scrollTo({
-      left: thumbCenterRelativeToStrip - strip.clientWidth / 2,
+      left: Math.max(0, Math.min(desired, maxScroll)),
       behavior: 'smooth',
     });
+    setTimeout(() => this.updateFades(strip), 350);
   }
 
   protected prev(): void {

--- a/src/clr-addons/image-gallery/image-carousel.ts
+++ b/src/clr-addons/image-gallery/image-carousel.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component, effect, ElementRef, HostListener, input, output, signal, ViewChild } from '@angular/core';
+import { circleArrowIcon, timesIcon, ClarityIcons } from '@cds/core/icon';
+import { ClrImageGalleryImage } from './image-gallery';
+
+ClarityIcons.addIcons(circleArrowIcon, timesIcon);
+
+@Component({
+  selector: 'clr-image-carousel',
+  templateUrl: './image-carousel.html',
+  styleUrls: ['./image-carousel.scss'],
+  standalone: false,
+})
+export class ClrImageCarousel {
+  @ViewChild('thumbStrip') private thumbStripRef?: ElementRef<HTMLElement>;
+
+  readonly images = input<ClrImageGalleryImage[]>([]);
+  readonly productName = input('');
+  readonly initialIndex = input(0);
+  /** When true the header row (title + close button) is not rendered. */
+  readonly hideHeader = input(false);
+
+  readonly closeCarousel = output<void>();
+
+  protected activeIndex = signal(0);
+  protected spacerWidth = signal(0);
+
+  private readonly thumbPx = 64;
+
+  constructor() {
+    // Seed activeIndex from initialIndex whenever it changes
+    effect(() => {
+      this.activeIndex.set(this.initialIndex());
+    });
+
+    effect(() => {
+      const index = this.activeIndex();
+      setTimeout(() => {
+        this.updateSpacerWidth();
+        this.scrollThumbIntoCenter(index);
+      });
+    });
+  }
+
+  private updateSpacerWidth(): void {
+    const strip = this.thumbStripRef?.nativeElement;
+    if (!strip) {
+      return;
+    }
+    this.spacerWidth.set(Math.max(0, strip.clientWidth / 2 - this.thumbPx / 2));
+  }
+
+  private scrollThumbIntoCenter(index: number): void {
+    const strip = this.thumbStripRef?.nativeElement;
+    if (!strip) {
+      return;
+    }
+    const thumb = strip.children[index + 1] as HTMLElement | undefined;
+    if (!thumb) {
+      return;
+    }
+    const stripRect = strip.getBoundingClientRect();
+    const thumbRect = thumb.getBoundingClientRect();
+    const thumbCenterRelativeToStrip = thumbRect.left - stripRect.left + thumbRect.width / 2 + strip.scrollLeft;
+    strip.scrollTo({
+      left: thumbCenterRelativeToStrip - strip.clientWidth / 2,
+      behavior: 'smooth',
+    });
+  }
+
+  protected prev(): void {
+    this.activeIndex.update(i => (i - 1 + this.images().length) % this.images().length);
+  }
+
+  protected next(): void {
+    this.activeIndex.update(i => (i + 1) % this.images().length);
+  }
+
+  protected setActive(index: number): void {
+    this.activeIndex.set(index);
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  protected onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'ArrowLeft') {
+      this.prev();
+    } else if (event.key === 'ArrowRight') {
+      this.next();
+    } else if (event.key === 'Escape') {
+      this.closeCarousel.emit();
+    }
+  }
+}

--- a/src/clr-addons/image-gallery/image-carousel.ts
+++ b/src/clr-addons/image-gallery/image-carousel.ts
@@ -6,7 +6,7 @@
 
 import { Component, effect, ElementRef, HostListener, input, output, signal, ViewChild } from '@angular/core';
 import { circleArrowIcon, timesIcon, ClarityIcons } from '@cds/core/icon';
-import { ClrImageGalleryImage } from './image-gallery';
+import { ClrImageGalleryImage } from './image-gallery.types';
 
 ClarityIcons.addIcons(circleArrowIcon, timesIcon);
 

--- a/src/clr-addons/image-gallery/image-gallery.html
+++ b/src/clr-addons/image-gallery/image-gallery.html
@@ -5,9 +5,14 @@
   -->
 
 <!-- Static gallery view -->
-<div class="clr-image-gallery" (click)="openModal(0)" [style.width.px]="spotlightSize()">
+<div class="clr-image-gallery" [style.width.px]="spotlightSize()">
   <!-- Spotlight image -->
-  <div class="clr-image-gallery__spotlight" [style.width.px]="spotlightSize()" [style.height.px]="spotlightSize()">
+  <div
+    class="clr-image-gallery__spotlight"
+    [style.width.px]="spotlightSize()"
+    [style.height.px]="spotlightSize()"
+    (click)="openModal(0)"
+  >
     <img
       *ngIf="images().length > 0"
       [ngSrc]="images()[0].src"
@@ -25,6 +30,7 @@
       class="clr-image-gallery__thumb"
       [style.width.px]="thumbnailSize()"
       [style.height.px]="thumbnailSize()"
+      (click)="openModal(i + 1)"
     >
       <img [src]="img.src" [alt]="img.alt || ''" class="clr-image-gallery__thumb-img" />
       <!-- Overlay on last thumbnail when there are more images -->

--- a/src/clr-addons/image-gallery/image-gallery.html
+++ b/src/clr-addons/image-gallery/image-gallery.html
@@ -60,6 +60,8 @@
       [images]="images()"
       [productName]="productName()"
       [initialIndex]="activeIndex()"
+      [imageSize]="carouselImageSize()"
+      [thumbnailSize]="carouselThumbnailSize()"
       (closeCarousel)="closeModal()"
     ></clr-image-carousel>
   </div>

--- a/src/clr-addons/image-gallery/image-gallery.html
+++ b/src/clr-addons/image-gallery/image-gallery.html
@@ -32,7 +32,13 @@
       [style.height.px]="thumbnailSize()"
       (click)="openModal(i + 1)"
     >
-      <img [src]="img.src" [alt]="img.alt || ''" class="clr-image-gallery__thumb-img" />
+      <img
+        [ngSrc]="img.src"
+        [width]="thumbnailSize()"
+        [height]="thumbnailSize()"
+        [alt]="img.alt || ''"
+        class="clr-image-gallery__thumb-img"
+      />
       <!-- Overlay on last thumbnail when there are more images -->
       <div class="clr-image-gallery__thumb-overlay" *ngIf="i === maxThumbnails - 1 && remainingCount() > 0">
         <span>{{ remainingCount() }}+</span>
@@ -41,64 +47,20 @@
   </div>
 </div>
 
-<!-- Carousel modal -->
+<!-- Built-in modal (only when useBuiltInModal is true) -->
 <div
   class="clr-image-gallery-backdrop"
-  *ngIf="modalOpen()"
+  *ngIf="useBuiltInModal() && modalOpen()"
   (click)="onBackdropClick($event)"
   role="dialog"
   aria-modal="true"
 >
   <div class="clr-image-gallery-modal">
-    <!-- Modal header -->
-    <div class="clr-image-gallery-modal__header">
-      <span class="clr-image-gallery-modal__title">{{ productName() }}</span>
-      <button class="clr-image-gallery-modal__close" (click)="closeModal()" aria-label="Close">
-        <cds-icon shape="times"></cds-icon>
-      </button>
-    </div>
-
-    <!-- Modal spotlight -->
-    <div class="clr-image-gallery-modal__spotlight">
-      <button
-        class="clr-image-gallery-modal__arrow clr-image-gallery-modal__arrow--prev"
-        (click)="prev()"
-        aria-label="Previous"
-      >
-        <cds-icon shape="circle-arrow" direction="left" solid></cds-icon>
-      </button>
-
-      <div class="clr-image-gallery-modal__img-wrap">
-        <img
-          [src]="images()[activeIndex()].src"
-          [alt]="images()[activeIndex()].alt || ''"
-          class="clr-image-gallery-modal__img"
-        />
-      </div>
-
-      <button
-        class="clr-image-gallery-modal__arrow clr-image-gallery-modal__arrow--next"
-        (click)="next()"
-        aria-label="Next"
-      >
-        <cds-icon shape="circle-arrow" direction="right" solid></cds-icon>
-      </button>
-    </div>
-
-    <!-- Modal thumbnail strip -->
-    <div class="clr-image-gallery-modal__thumbs-wrap">
-      <div class="clr-image-gallery-modal__thumbs" #thumbStrip>
-        <span class="clr-image-gallery-modal__thumbs-spacer" [style.width.px]="spacerWidth()"></span>
-        <div
-          *ngFor="let img of images(); let i = index"
-          class="clr-image-gallery-modal__thumb"
-          [class.clr-image-gallery-modal__thumb--active]="i === activeIndex()"
-          (click)="setActive(i)"
-        >
-          <img [src]="img.src" [alt]="img.alt || ''" class="clr-image-gallery-modal__thumb-img" />
-        </div>
-        <span class="clr-image-gallery-modal__thumbs-spacer" [style.width.px]="spacerWidth()"></span>
-      </div>
-    </div>
+    <clr-image-carousel
+      [images]="images()"
+      [productName]="productName()"
+      [initialIndex]="activeIndex()"
+      (closeCarousel)="closeModal()"
+    ></clr-image-carousel>
   </div>
 </div>

--- a/src/clr-addons/image-gallery/image-gallery.html
+++ b/src/clr-addons/image-gallery/image-gallery.html
@@ -1,0 +1,94 @@
+<!--
+  ~ Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<!-- Static gallery view -->
+<div class="clr-image-gallery" (click)="openModal(0)" [style.width.px]="spotlightSize()">
+  <!-- Spotlight image -->
+  <div class="clr-image-gallery__spotlight" [style.width.px]="spotlightSize()" [style.height.px]="spotlightSize()">
+    <img
+      *ngIf="images().length > 0"
+      [ngSrc]="images()[0].src"
+      [width]="spotlightSize()"
+      [height]="spotlightSize()"
+      [alt]="images()[0].alt || ''"
+      class="clr-image-gallery__spotlight-img"
+    />
+  </div>
+
+  <!-- Thumbnail row -->
+  <div class="clr-image-gallery__thumbs" *ngIf="images().length > 1">
+    <div
+      *ngFor="let img of staticThumbnails(); let i = index"
+      class="clr-image-gallery__thumb"
+      [style.width.px]="thumbnailSize()"
+      [style.height.px]="thumbnailSize()"
+    >
+      <img [src]="img.src" [alt]="img.alt || ''" class="clr-image-gallery__thumb-img" />
+      <!-- Overlay on last thumbnail when there are more images -->
+      <div class="clr-image-gallery__thumb-overlay" *ngIf="i === maxThumbnails - 1 && remainingCount() > 0">
+        <span>+{{ remainingCount() }}</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Carousel modal -->
+<div
+  class="clr-image-gallery-backdrop"
+  *ngIf="modalOpen()"
+  (click)="onBackdropClick($event)"
+  role="dialog"
+  aria-modal="true"
+>
+  <div class="clr-image-gallery-modal">
+    <!-- Modal header -->
+    <div class="clr-image-gallery-modal__header">
+      <span class="clr-image-gallery-modal__title">{{ productName() }}</span>
+      <button class="clr-image-gallery-modal__close" (click)="closeModal()" aria-label="Close">
+        <cds-icon shape="times"></cds-icon>
+      </button>
+    </div>
+
+    <!-- Modal spotlight -->
+    <div class="clr-image-gallery-modal__spotlight">
+      <button
+        class="clr-image-gallery-modal__arrow clr-image-gallery-modal__arrow--prev"
+        (click)="prev()"
+        aria-label="Previous"
+      >
+        <cds-icon shape="angle" direction="left"></cds-icon>
+      </button>
+
+      <div class="clr-image-gallery-modal__img-wrap">
+        <img
+          [src]="images()[activeIndex()].src"
+          [alt]="images()[activeIndex()].alt || ''"
+          class="clr-image-gallery-modal__img"
+        />
+      </div>
+
+      <button
+        class="clr-image-gallery-modal__arrow clr-image-gallery-modal__arrow--next"
+        (click)="next()"
+        aria-label="Next"
+      >
+        <cds-icon shape="angle" direction="right"></cds-icon>
+      </button>
+    </div>
+
+    <!-- Modal thumbnail strip -->
+    <div class="clr-image-gallery-modal__thumbs">
+      <div
+        *ngFor="let img of images(); let i = index"
+        class="clr-image-gallery-modal__thumb"
+        [class.clr-image-gallery-modal__thumb--active]="i === activeIndex()"
+        (click)="setActive(i)"
+      >
+        <img [src]="img.src" [alt]="img.alt || ''" class="clr-image-gallery-modal__thumb-img" />
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/clr-addons/image-gallery/image-gallery.html
+++ b/src/clr-addons/image-gallery/image-gallery.html
@@ -29,7 +29,7 @@
       <img [src]="img.src" [alt]="img.alt || ''" class="clr-image-gallery__thumb-img" />
       <!-- Overlay on last thumbnail when there are more images -->
       <div class="clr-image-gallery__thumb-overlay" *ngIf="i === maxThumbnails - 1 && remainingCount() > 0">
-        <span>+{{ remainingCount() }}</span>
+        <span>{{ remainingCount() }}+</span>
       </div>
     </div>
   </div>
@@ -59,7 +59,7 @@
         (click)="prev()"
         aria-label="Previous"
       >
-        <cds-icon shape="angle" direction="left"></cds-icon>
+        <cds-icon shape="circle-arrow" direction="left" solid></cds-icon>
       </button>
 
       <div class="clr-image-gallery-modal__img-wrap">
@@ -75,19 +75,23 @@
         (click)="next()"
         aria-label="Next"
       >
-        <cds-icon shape="angle" direction="right"></cds-icon>
+        <cds-icon shape="circle-arrow" direction="right" solid></cds-icon>
       </button>
     </div>
 
     <!-- Modal thumbnail strip -->
-    <div class="clr-image-gallery-modal__thumbs">
-      <div
-        *ngFor="let img of images(); let i = index"
-        class="clr-image-gallery-modal__thumb"
-        [class.clr-image-gallery-modal__thumb--active]="i === activeIndex()"
-        (click)="setActive(i)"
-      >
-        <img [src]="img.src" [alt]="img.alt || ''" class="clr-image-gallery-modal__thumb-img" />
+    <div class="clr-image-gallery-modal__thumbs-wrap">
+      <div class="clr-image-gallery-modal__thumbs" #thumbStrip>
+        <span class="clr-image-gallery-modal__thumbs-spacer" [style.width.px]="spacerWidth()"></span>
+        <div
+          *ngFor="let img of images(); let i = index"
+          class="clr-image-gallery-modal__thumb"
+          [class.clr-image-gallery-modal__thumb--active]="i === activeIndex()"
+          (click)="setActive(i)"
+        >
+          <img [src]="img.src" [alt]="img.alt || ''" class="clr-image-gallery-modal__thumb-img" />
+        </div>
+        <span class="clr-image-gallery-modal__thumbs-spacer" [style.width.px]="spacerWidth()"></span>
       </div>
     </div>
   </div>

--- a/src/clr-addons/image-gallery/image-gallery.module.ts
+++ b/src/clr-addons/image-gallery/image-gallery.module.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ClarityModule } from '@clr/angular';
+
+import { ClrImageGallery } from './image-gallery';
+
+@NgModule({
+  imports: [CommonModule, ClarityModule, NgOptimizedImage],
+  declarations: [ClrImageGallery],
+  exports: [ClrImageGallery],
+})
+export class ClrImageGalleryModule {}

--- a/src/clr-addons/image-gallery/image-gallery.module.ts
+++ b/src/clr-addons/image-gallery/image-gallery.module.ts
@@ -9,10 +9,11 @@ import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
 
 import { ClrImageGallery } from './image-gallery';
+import { ClrImageCarousel } from './image-carousel';
 
 @NgModule({
   imports: [CommonModule, ClarityModule, NgOptimizedImage],
-  declarations: [ClrImageGallery],
-  exports: [ClrImageGallery],
+  declarations: [ClrImageGallery, ClrImageCarousel],
+  exports: [ClrImageGallery, ClrImageCarousel],
 })
 export class ClrImageGalleryModule {}

--- a/src/clr-addons/image-gallery/image-gallery.scss
+++ b/src/clr-addons/image-gallery/image-gallery.scss
@@ -58,7 +58,7 @@
   }
 }
 
-// ─── Modal backdrop ───────────────────────────────────────────────────────────
+// ─── Built-in modal backdrop ──────────────────────────────────────────────────
 
 .clr-image-gallery-backdrop {
   position: fixed;
@@ -70,23 +70,13 @@
   z-index: 10000;
 }
 
-// ─── Modal panel ─────────────────────────────────────────────────────────────
-// Modal is locked to 96vh. Image fills the remaining height after header and
-// thumbnail strip, maintaining a 1:1 aspect ratio. Modal width = image + 2×24px.
-//
-// Header:     24px top + ~20px text + 24px bottom  = 68px
-// Thumb row:  8px top  + 24px thumb + 24px bottom  = 56px
-// Image side: 96vh - 68px - 56px                   = calc(96vh - 124px)
-// Modal width: image + 2×24px                      = calc(96vh - 76px)
-
+// Modal shell – dimensions mirror image-carousel.scss so the carousel fills it.
 $modal-pad: 24px;
 $modal-header-h: 68px;
 $modal-thumb-size: 64px;
-$modal-thumb-gap: 8px;
 $modal-img-to-thumbs: 8px;
 $modal-bottom-pad: $modal-pad;
-$modal-thumb-row-h: $modal-img-to-thumbs + $modal-thumb-size + $modal-bottom-pad; // 96px
-$modal-img-side: calc(96vh - #{$modal-header-h} - #{$modal-thumb-row-h});
+$modal-thumb-row-h: $modal-img-to-thumbs + $modal-thumb-size + $modal-bottom-pad;
 $modal-width: calc(96vh - #{$modal-header-h} - #{$modal-thumb-row-h} + #{$modal-pad * 2});
 
 .clr-image-gallery-modal {
@@ -99,177 +89,4 @@ $modal-width: calc(96vh - #{$modal-header-h} - #{$modal-thumb-row-h} + #{$modal-
   max-width: 98vw;
   overflow: hidden;
   box-shadow: 0 4px 32px rgba(0, 0, 0, 0.35);
-
-  &__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    height: $modal-header-h;
-    padding: 0 $modal-pad;
-    flex-shrink: 0;
-    box-sizing: border-box;
-  }
-
-  &__title {
-    font-size: 14px;
-    font-weight: 400;
-    line-height: 24px;
-  }
-
-  &__close {
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 4px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: inherit;
-
-    cds-icon {
-      --color: currentColor;
-      width: 18px;
-      height: 18px;
-    }
-
-    &:hover {
-      opacity: 0.7;
-    }
-  }
-
-  &__spotlight {
-    position: relative;
-    flex-shrink: 0;
-    padding: 0 $modal-pad;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  &__img-wrap {
-    width: $modal-img-side;
-    height: $modal-img-side;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    overflow: hidden;
-    border-radius: 3px;
-  }
-
-  &__img {
-    display: block;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-
-  &__arrow {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    z-index: 1;
-    background: none;
-    border: none;
-    padding: 0;
-    outline: none;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    opacity: 0.25;
-    transition: opacity 0.15s;
-
-    &:focus {
-      outline: none;
-    }
-
-    &:hover {
-      opacity: 1;
-    }
-
-    &--prev {
-      left: $modal-pad + 12px;
-    }
-
-    &--next {
-      right: $modal-pad + 12px;
-    }
-
-    cds-icon {
-      --color: white;
-      width: 56px;
-      height: 56px;
-    }
-  }
-
-  &__thumbs-wrap {
-    position: relative;
-    flex-shrink: 0;
-
-    &::before,
-    &::after {
-      content: '';
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      width: 48px;
-      z-index: 1;
-      pointer-events: none;
-    }
-
-    &::before {
-      left: 0;
-      background: linear-gradient(to right, var(--clr-modal-bg-color, #fff), transparent);
-    }
-
-    &::after {
-      right: 0;
-      background: linear-gradient(to left, var(--clr-modal-bg-color, #fff), transparent);
-    }
-  }
-
-  &__thumbs {
-    display: flex;
-    gap: $modal-thumb-gap;
-    padding: $modal-img-to-thumbs 0 $modal-bottom-pad 0;
-    overflow-x: auto;
-    flex-shrink: 0;
-    scroll-behavior: smooth;
-    scrollbar-width: none;
-
-    &::-webkit-scrollbar {
-      display: none;
-    }
-  }
-
-  &__thumbs-spacer {
-    flex-shrink: 0;
-  }
-
-  &__thumb {
-    width: $modal-thumb-size;
-    height: $modal-thumb-size;
-    flex-shrink: 0;
-    overflow: hidden;
-    cursor: pointer;
-    border-radius: 3px;
-    outline: 4px solid transparent;
-    outline-offset: -4px;
-    transition: outline-color 0.15s;
-
-    &--active {
-      outline-color: #14a1a9;
-    }
-
-    &:hover:not(&--active) {
-      outline-color: var(--clr-color-neutral-400, #aaa);
-    }
-  }
-
-  &__thumb-img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    display: block;
-  }
 }

--- a/src/clr-addons/image-gallery/image-gallery.scss
+++ b/src/clr-addons/image-gallery/image-gallery.scss
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+// ─── Static gallery ──────────────────────────────────────────────────────────
+
+.clr-image-gallery {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  user-select: none;
+
+  &__spotlight {
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+
+  &__spotlight-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  &__thumbs {
+    display: flex;
+    gap: 4px;
+  }
+
+  &__thumb {
+    position: relative;
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+
+  &__thumb-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  &__thumb-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+}
+
+// ─── Modal backdrop ───────────────────────────────────────────────────────────
+
+.clr-image-gallery-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+// ─── Modal panel ─────────────────────────────────────────────────────────────
+
+.clr-image-gallery-modal {
+  background: var(--clr-modal-bg-color, #fff);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow: hidden;
+  box-shadow: 0 4px 32px rgba(0, 0, 0, 0.35);
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--clr-modal-header-border-color, #e0e0e0);
+    flex-shrink: 0;
+  }
+
+  &__title {
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  &__close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: inherit;
+
+    cds-icon {
+      --color: currentColor;
+      width: 18px;
+      height: 18px;
+    }
+
+    &:hover {
+      opacity: 0.7;
+    }
+  }
+
+  &__spotlight {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1 1 auto;
+    min-height: 0;
+    padding: 12px;
+    gap: 8px;
+  }
+
+  &__img-wrap {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    max-height: 60vh;
+    overflow: hidden;
+  }
+
+  &__img {
+    max-width: 100%;
+    max-height: 60vh;
+    object-fit: contain;
+    display: block;
+  }
+
+  &__arrow {
+    background: none;
+    border: 1px solid var(--clr-btn-default-border-color, #ccc);
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+    color: inherit;
+
+    cds-icon {
+      --color: currentColor;
+      width: 16px;
+      height: 16px;
+    }
+
+    &:hover {
+      background: var(--clr-btn-default-hover-bg-color, #f0f0f0);
+    }
+  }
+
+  &__thumbs {
+    display: flex;
+    justify-content: center;
+    gap: 6px;
+    padding: 10px 16px;
+    overflow-x: auto;
+    flex-shrink: 0;
+    border-top: 1px solid var(--clr-modal-header-border-color, #e0e0e0);
+  }
+
+  &__thumb {
+    width: 64px;
+    height: 64px;
+    flex-shrink: 0;
+    overflow: hidden;
+    cursor: pointer;
+    border: 2px solid transparent;
+    border-radius: 2px;
+    transition: border-color 0.15s;
+
+    &--active {
+      border-color: var(--clr-color-action-600, #0072a3);
+    }
+
+    &:hover:not(&--active) {
+      border-color: var(--clr-color-neutral-400, #aaa);
+    }
+  }
+
+  &__thumb-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}

--- a/src/clr-addons/image-gallery/image-gallery.scss
+++ b/src/clr-addons/image-gallery/image-gallery.scss
@@ -9,13 +9,14 @@
 .clr-image-gallery {
   display: inline-flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
   cursor: pointer;
   user-select: none;
 
   &__spotlight {
     overflow: hidden;
     flex-shrink: 0;
+    border-radius: 3px;
   }
 
   &__spotlight-img {
@@ -27,13 +28,14 @@
 
   &__thumbs {
     display: flex;
-    gap: 4px;
+    gap: 8px;
   }
 
   &__thumb {
     position: relative;
     overflow: hidden;
     flex-shrink: 0;
+    border-radius: 3px;
   }
 
   &__thumb-img {
@@ -46,12 +48,12 @@
   &__thumb-overlay {
     position: absolute;
     inset: 0;
-    background: rgba(0, 0, 0, 0.55);
+    background: rgba(0, 0, 0, 0.5);
     display: flex;
     align-items: center;
     justify-content: center;
     color: #fff;
-    font-size: 1.25rem;
+    font-size: 13px;
     font-weight: 600;
   }
 }
@@ -69,14 +71,32 @@
 }
 
 // ─── Modal panel ─────────────────────────────────────────────────────────────
+// Modal is locked to 96vh. Image fills the remaining height after header and
+// thumbnail strip, maintaining a 1:1 aspect ratio. Modal width = image + 2×24px.
+//
+// Header:     24px top + ~20px text + 24px bottom  = 68px
+// Thumb row:  8px top  + 24px thumb + 24px bottom  = 56px
+// Image side: 96vh - 68px - 56px                   = calc(96vh - 124px)
+// Modal width: image + 2×24px                      = calc(96vh - 76px)
+
+$modal-pad: 24px;
+$modal-header-h: 68px;
+$modal-thumb-size: 64px;
+$modal-thumb-gap: 8px;
+$modal-img-to-thumbs: 8px;
+$modal-bottom-pad: $modal-pad;
+$modal-thumb-row-h: $modal-img-to-thumbs + $modal-thumb-size + $modal-bottom-pad; // 96px
+$modal-img-side: calc(96vh - #{$modal-header-h} - #{$modal-thumb-row-h});
+$modal-width: calc(96vh - #{$modal-header-h} - #{$modal-thumb-row-h} + #{$modal-pad * 2});
 
 .clr-image-gallery-modal {
   background: var(--clr-modal-bg-color, #fff);
   border-radius: 4px;
   display: flex;
   flex-direction: column;
-  max-width: 90vw;
-  max-height: 90vh;
+  height: 96vh;
+  width: $modal-width;
+  max-width: 98vw;
   overflow: hidden;
   box-shadow: 0 4px 32px rgba(0, 0, 0, 0.35);
 
@@ -84,14 +104,16 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 12px 16px;
-    border-bottom: 1px solid var(--clr-modal-header-border-color, #e0e0e0);
+    height: $modal-header-h;
+    padding: 0 $modal-pad;
     flex-shrink: 0;
+    box-sizing: border-box;
   }
 
   &__title {
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 24px;
   }
 
   &__close {
@@ -116,82 +138,131 @@
   }
 
   &__spotlight {
+    position: relative;
+    flex-shrink: 0;
+    padding: 0 $modal-pad;
     display: flex;
     align-items: center;
     justify-content: center;
-    flex: 1 1 auto;
-    min-height: 0;
-    padding: 12px;
-    gap: 8px;
   }
 
   &__img-wrap {
-    flex: 1 1 auto;
-    min-width: 0;
+    width: $modal-img-side;
+    height: $modal-img-side;
     display: flex;
     align-items: center;
     justify-content: center;
-    max-height: 60vh;
     overflow: hidden;
+    border-radius: 3px;
   }
 
   &__img {
-    max-width: 100%;
-    max-height: 60vh;
-    object-fit: contain;
     display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
   }
 
   &__arrow {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 1;
     background: none;
-    border: 1px solid var(--clr-btn-default-border-color, #ccc);
-    border-radius: 50%;
-    width: 36px;
-    height: 36px;
+    border: none;
+    padding: 0;
+    outline: none;
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    flex-shrink: 0;
-    color: inherit;
+    opacity: 0.25;
+    transition: opacity 0.15s;
 
-    cds-icon {
-      --color: currentColor;
-      width: 16px;
-      height: 16px;
+    &:focus {
+      outline: none;
     }
 
     &:hover {
-      background: var(--clr-btn-default-hover-bg-color, #f0f0f0);
+      opacity: 1;
+    }
+
+    &--prev {
+      left: $modal-pad + 12px;
+    }
+
+    &--next {
+      right: $modal-pad + 12px;
+    }
+
+    cds-icon {
+      --color: white;
+      width: 56px;
+      height: 56px;
+    }
+  }
+
+  &__thumbs-wrap {
+    position: relative;
+    flex-shrink: 0;
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 48px;
+      z-index: 1;
+      pointer-events: none;
+    }
+
+    &::before {
+      left: 0;
+      background: linear-gradient(to right, var(--clr-modal-bg-color, #fff), transparent);
+    }
+
+    &::after {
+      right: 0;
+      background: linear-gradient(to left, var(--clr-modal-bg-color, #fff), transparent);
     }
   }
 
   &__thumbs {
     display: flex;
-    justify-content: center;
-    gap: 6px;
-    padding: 10px 16px;
+    gap: $modal-thumb-gap;
+    padding: $modal-img-to-thumbs 0 $modal-bottom-pad 0;
     overflow-x: auto;
     flex-shrink: 0;
-    border-top: 1px solid var(--clr-modal-header-border-color, #e0e0e0);
+    scroll-behavior: smooth;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  &__thumbs-spacer {
+    flex-shrink: 0;
   }
 
   &__thumb {
-    width: 64px;
-    height: 64px;
+    width: $modal-thumb-size;
+    height: $modal-thumb-size;
     flex-shrink: 0;
     overflow: hidden;
     cursor: pointer;
-    border: 2px solid transparent;
-    border-radius: 2px;
-    transition: border-color 0.15s;
+    border-radius: 3px;
+    outline: 4px solid transparent;
+    outline-offset: -4px;
+    transition: outline-color 0.15s;
 
     &--active {
-      border-color: var(--clr-color-action-600, #0072a3);
+      outline-color: #14a1a9;
     }
 
     &:hover:not(&--active) {
-      border-color: var(--clr-color-neutral-400, #aaa);
+      outline-color: var(--clr-color-neutral-400, #aaa);
     }
   }
 

--- a/src/clr-addons/image-gallery/image-gallery.ts
+++ b/src/clr-addons/image-gallery/image-gallery.ts
@@ -4,14 +4,16 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, computed, effect, ElementRef, HostListener, input, signal, ViewChild } from '@angular/core';
-import { circleArrowIcon, timesIcon, ClarityIcons } from '@cds/core/icon';
-
-ClarityIcons.addIcons(circleArrowIcon, timesIcon);
+import { Component, computed, input, output, signal } from '@angular/core';
 
 export interface ClrImageGalleryImage {
   src: string;
   alt?: string;
+}
+
+export interface ClrImageGalleryOpenEvent {
+  images: ClrImageGalleryImage[];
+  index: number;
 }
 
 @Component({
@@ -21,19 +23,23 @@ export interface ClrImageGalleryImage {
   standalone: false,
 })
 export class ClrImageGallery {
-  @ViewChild('thumbStrip') private thumbStripRef?: ElementRef<HTMLElement>;
-
-  protected images = input<ClrImageGalleryImage[]>([]);
-  protected productName = input('');
+  readonly images = input<ClrImageGalleryImage[]>([]);
+  readonly productName = input('');
   /** Size in pixels of the spotlighted image in the static view */
-  protected spotlightSize = input(284);
+  readonly spotlightSize = input(284);
+  /**
+   * When true (default), clicking opens a built-in full-screen modal.
+   * When false, emits `galleryOpen` so the parent can embed the carousel.
+   */
+  readonly useBuiltInModal = input(true);
+
+  /** Emitted when useBuiltInModal is false and the user clicks an image. */
+  readonly galleryOpen = output<ClrImageGalleryOpenEvent>();
 
   protected modalOpen = signal(false);
   protected activeIndex = signal(0);
-  protected spacerWidth = signal(0);
 
   protected maxThumbnails = 4;
-  private readonly thumbPx = 64;
 
   protected readonly thumbnailSize = computed(() => {
     const totalPadding = 8 * (this.maxThumbnails - 1);
@@ -42,84 +48,21 @@ export class ClrImageGallery {
   protected readonly staticThumbnails = computed(() => this.images().slice(1, this.maxThumbnails + 1));
   protected readonly remainingCount = computed(() => this.images().length - this.maxThumbnails - 1);
 
-  constructor() {
-    effect(() => {
-      const index = this.activeIndex();
-      const open = this.modalOpen();
-      // Wait for DOM to settle (modal *ngIf + thumbnail *ngFor)
-      setTimeout(() => {
-        if (open) {
-          this.updateSpacerWidth();
-          this.scrollThumbIntoCenter(index);
-        }
-      });
-    });
-  }
-
-  private updateSpacerWidth(): void {
-    const strip = this.thumbStripRef?.nativeElement;
-    if (!strip) {
-      return;
-    }
-    this.spacerWidth.set(Math.max(0, strip.clientWidth / 2 - this.thumbPx / 2));
-  }
-
-  private scrollThumbIntoCenter(index: number): void {
-    const strip = this.thumbStripRef?.nativeElement;
-    if (!strip) {
-      return;
-    }
-    // children[0] is the leading spacer <span>, thumbnails start at children[1]
-    const thumb = strip.children[index + 1] as HTMLElement | undefined;
-    if (!thumb) {
-      return;
-    }
-    const stripRect = strip.getBoundingClientRect();
-    const thumbRect = thumb.getBoundingClientRect();
-    const thumbCenterRelativeToStrip = thumbRect.left - stripRect.left + thumbRect.width / 2 + strip.scrollLeft;
-    strip.scrollTo({
-      left: thumbCenterRelativeToStrip - strip.clientWidth / 2,
-      behavior: 'smooth',
-    });
-  }
-
   protected openModal(index = 0): void {
-    this.activeIndex.set(index);
-    this.modalOpen.set(true);
+    if (this.useBuiltInModal()) {
+      this.activeIndex.set(index);
+      this.modalOpen.set(true);
+    } else {
+      this.galleryOpen.emit({ images: this.images(), index });
+    }
   }
 
   protected closeModal(): void {
     this.modalOpen.set(false);
   }
 
-  protected prev(): void {
-    this.activeIndex.update(i => (i - 1 + this.images().length) % this.images().length);
-  }
-
-  protected next(): void {
-    this.activeIndex.update(i => (i + 1) % this.images().length);
-  }
-
-  protected setActive(index: number): void {
-    this.activeIndex.set(index);
-  }
-
   protected onBackdropClick(event: MouseEvent): void {
     if ((event.target as HTMLElement).classList.contains('clr-image-gallery-backdrop')) {
-      this.closeModal();
-    }
-  }
-
-  @HostListener('document:keydown', ['$event'])
-  protected onKeydown(event: KeyboardEvent): void {
-    if (!this.modalOpen()) {
-      return;
-    }
-    if (event.key === 'ArrowLeft') {
-      this.prev();
-    } else if (event.key === 'ArrowRight') {
-      this.next();
-    } else if (event.key === 'Escape') {
       this.closeModal();
     }
   }

--- a/src/clr-addons/image-gallery/image-gallery.ts
+++ b/src/clr-addons/image-gallery/image-gallery.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component, computed, input, signal } from '@angular/core';
+import { angleIcon, timesIcon, ClarityIcons } from '@cds/core/icon';
+
+ClarityIcons.addIcons(angleIcon, timesIcon);
+
+export interface ClrImageGalleryImage {
+  src: string;
+  alt?: string;
+}
+
+@Component({
+  selector: 'clr-image-gallery',
+  templateUrl: './image-gallery.html',
+  styleUrls: ['./image-gallery.scss'],
+  standalone: false,
+})
+export class ClrImageGallery {
+  protected images = input<ClrImageGalleryImage[]>([]);
+  protected productName = input('');
+  /** Size in pixels of the spotlighted image in the static view */
+  protected spotlightSize = input(400);
+
+  protected modalOpen = signal(false);
+  protected activeIndex = signal(0);
+
+  protected maxThumbnails = 4;
+
+  protected readonly thumbnailSize = computed(() => {
+    const totalPadding = 4 * (this.maxThumbnails - 1);
+    return (this.spotlightSize() - totalPadding) / this.maxThumbnails;
+  });
+  protected readonly staticThumbnails = computed(() => this.images().slice(1, this.maxThumbnails + 1));
+  protected readonly remainingCount = computed(() => this.images().length - this.maxThumbnails - 1);
+
+  protected openModal(index = 0): void {
+    this.activeIndex.set(index);
+    this.modalOpen.set(true);
+  }
+
+  protected closeModal(): void {
+    this.modalOpen.set(false);
+  }
+
+  protected prev(): void {
+    this.activeIndex.update(i => (i - 1 + this.images().length) % this.images().length);
+  }
+
+  protected next(): void {
+    this.activeIndex.update(i => (i + 1) % this.images().length);
+  }
+
+  protected setActive(index: number): void {
+    this.activeIndex.set(index);
+  }
+
+  protected onBackdropClick(event: MouseEvent): void {
+    if ((event.target as HTMLElement).classList.contains('clr-image-gallery-backdrop')) {
+      this.closeModal();
+    }
+  }
+}

--- a/src/clr-addons/image-gallery/image-gallery.ts
+++ b/src/clr-addons/image-gallery/image-gallery.ts
@@ -4,10 +4,10 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, computed, input, signal } from '@angular/core';
-import { angleIcon, timesIcon, ClarityIcons } from '@cds/core/icon';
+import { Component, computed, effect, ElementRef, HostListener, input, signal, ViewChild } from '@angular/core';
+import { circleArrowIcon, timesIcon, ClarityIcons } from '@cds/core/icon';
 
-ClarityIcons.addIcons(angleIcon, timesIcon);
+ClarityIcons.addIcons(circleArrowIcon, timesIcon);
 
 export interface ClrImageGalleryImage {
   src: string;
@@ -21,22 +21,67 @@ export interface ClrImageGalleryImage {
   standalone: false,
 })
 export class ClrImageGallery {
+  @ViewChild('thumbStrip') private thumbStripRef?: ElementRef<HTMLElement>;
+
   protected images = input<ClrImageGalleryImage[]>([]);
   protected productName = input('');
   /** Size in pixels of the spotlighted image in the static view */
-  protected spotlightSize = input(400);
+  protected spotlightSize = input(284);
 
   protected modalOpen = signal(false);
   protected activeIndex = signal(0);
+  protected spacerWidth = signal(0);
 
   protected maxThumbnails = 4;
+  private readonly thumbPx = 64;
 
   protected readonly thumbnailSize = computed(() => {
-    const totalPadding = 4 * (this.maxThumbnails - 1);
+    const totalPadding = 8 * (this.maxThumbnails - 1);
     return (this.spotlightSize() - totalPadding) / this.maxThumbnails;
   });
   protected readonly staticThumbnails = computed(() => this.images().slice(1, this.maxThumbnails + 1));
   protected readonly remainingCount = computed(() => this.images().length - this.maxThumbnails - 1);
+
+  constructor() {
+    effect(() => {
+      const index = this.activeIndex();
+      const open = this.modalOpen();
+      // Wait for DOM to settle (modal *ngIf + thumbnail *ngFor)
+      setTimeout(() => {
+        if (open) {
+          this.updateSpacerWidth();
+          this.scrollThumbIntoCenter(index);
+        }
+      });
+    });
+  }
+
+  private updateSpacerWidth(): void {
+    const strip = this.thumbStripRef?.nativeElement;
+    if (!strip) {
+      return;
+    }
+    this.spacerWidth.set(Math.max(0, strip.clientWidth / 2 - this.thumbPx / 2));
+  }
+
+  private scrollThumbIntoCenter(index: number): void {
+    const strip = this.thumbStripRef?.nativeElement;
+    if (!strip) {
+      return;
+    }
+    // children[0] is the leading spacer <span>, thumbnails start at children[1]
+    const thumb = strip.children[index + 1] as HTMLElement | undefined;
+    if (!thumb) {
+      return;
+    }
+    const stripRect = strip.getBoundingClientRect();
+    const thumbRect = thumb.getBoundingClientRect();
+    const thumbCenterRelativeToStrip = thumbRect.left - stripRect.left + thumbRect.width / 2 + strip.scrollLeft;
+    strip.scrollTo({
+      left: thumbCenterRelativeToStrip - strip.clientWidth / 2,
+      behavior: 'smooth',
+    });
+  }
 
   protected openModal(index = 0): void {
     this.activeIndex.set(index);
@@ -61,6 +106,20 @@ export class ClrImageGallery {
 
   protected onBackdropClick(event: MouseEvent): void {
     if ((event.target as HTMLElement).classList.contains('clr-image-gallery-backdrop')) {
+      this.closeModal();
+    }
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  protected onKeydown(event: KeyboardEvent): void {
+    if (!this.modalOpen()) {
+      return;
+    }
+    if (event.key === 'ArrowLeft') {
+      this.prev();
+    } else if (event.key === 'ArrowRight') {
+      this.next();
+    } else if (event.key === 'Escape') {
       this.closeModal();
     }
   }

--- a/src/clr-addons/image-gallery/image-gallery.ts
+++ b/src/clr-addons/image-gallery/image-gallery.ts
@@ -5,16 +5,9 @@
  */
 
 import { Component, computed, input, output, signal } from '@angular/core';
+import { ClrImageGalleryImage, ClrImageGalleryOpenEvent } from './image-gallery.types';
 
-export interface ClrImageGalleryImage {
-  src: string;
-  alt?: string;
-}
-
-export interface ClrImageGalleryOpenEvent {
-  images: ClrImageGalleryImage[];
-  index: number;
-}
+export { ClrImageGalleryImage, ClrImageGalleryOpenEvent };
 
 @Component({
   selector: 'clr-image-gallery',

--- a/src/clr-addons/image-gallery/image-gallery.ts
+++ b/src/clr-addons/image-gallery/image-gallery.ts
@@ -36,6 +36,11 @@ export class ClrImageGallery {
   /** Emitted when useBuiltInModal is false and the user clicks an image. */
   readonly galleryOpen = output<ClrImageGalleryOpenEvent>();
 
+  /** Size in pixels of the active image in the carousel. 0 (default) = auto-fit container width. */
+  readonly carouselImageSize = input(0);
+  /** Size in pixels of each thumbnail in the carousel. Defaults to 64px. */
+  readonly carouselThumbnailSize = input(64);
+
   protected modalOpen = signal(false);
   protected activeIndex = signal(0);
 

--- a/src/clr-addons/image-gallery/image-gallery.types.ts
+++ b/src/clr-addons/image-gallery/image-gallery.types.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export interface ClrImageGalleryImage {
+  src: string;
+  alt?: string;
+}
+
+export interface ClrImageGalleryOpenEvent {
+  images: ClrImageGalleryImage[];
+  index: number;
+}

--- a/src/clr-addons/image-gallery/index.ts
+++ b/src/clr-addons/image-gallery/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export * from './image-gallery';
+export * from './image-gallery.module';

--- a/src/clr-addons/image-gallery/index.ts
+++ b/src/clr-addons/image-gallery/index.ts
@@ -5,4 +5,5 @@
  */
 
 export * from './image-gallery';
+export * from './image-carousel';
 export * from './image-gallery.module';

--- a/src/clr-addons/index.ts
+++ b/src/clr-addons/index.ts
@@ -48,3 +48,4 @@ export * from './signpost/index';
 export * from './focus-first-invalid-field/index';
 export * from './control-enter-submit/index';
 export * from './keyboard-nav/index';
+export * from './image-gallery/index';

--- a/src/dev/src/app/app.routing.ts
+++ b/src/dev/src/app/app.routing.ts
@@ -214,6 +214,10 @@ export const APP_ROUTES: Routes = [
     path: 'image-gallery',
     loadComponent: () => import('./image-gallery/image-gallery.demo').then(m => m.ImageGalleryDemo),
   },
+  {
+    path: 'image-gallery-in-modal',
+    loadComponent: () => import('./image-gallery/image-gallery-in-modal.demo').then(m => m.ImageGalleryInModalDemo),
+  },
 ];
 
 export const ROUTING: ModuleWithProviders<RouterModule> = RouterModule.forRoot(APP_ROUTES);

--- a/src/dev/src/app/app.routing.ts
+++ b/src/dev/src/app/app.routing.ts
@@ -210,6 +210,10 @@ export const APP_ROUTES: Routes = [
     path: 'keyboard-nav',
     loadComponent: () => import('./keyboard-nav/keyboard-nav.demo').then(m => m.KeyboardNavDemo),
   },
+  {
+    path: 'image-gallery',
+    loadComponent: () => import('./image-gallery/image-gallery.demo').then(m => m.ImageGalleryDemo),
+  },
 ];
 
 export const ROUTING: ModuleWithProviders<RouterModule> = RouterModule.forRoot(APP_ROUTES);

--- a/src/dev/src/app/image-gallery/image-gallery-in-modal.demo.html
+++ b/src/dev/src/app/image-gallery/image-gallery-in-modal.demo.html
@@ -1,0 +1,62 @@
+<!--
+  Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+  This software is released under MIT license.
+  The full license information can be found in LICENSE in the root directory of this project.
+-->
+
+<h2>Image Gallery in Modal Demo</h2>
+<p>
+  The gallery is embedded inside a Clarity modal with <code>[useBuiltInModal]="false"</code>. Clicking an image replaces
+  the modal content with the carousel instead of opening a nested modal.
+</p>
+
+<button class="btn btn-primary" (click)="openModal()">Open Modal</button>
+
+<clr-modal [clrModalOpen]="modalOpen()" (clrModalOpenChange)="$event ? null : onModalClose()" clrModalSize="lg">
+  <h3 class="modal-title">
+    <button
+      *ngIf="showCarousel()"
+      class="btn btn-icon btn-link"
+      style="
+        margin: 0 4px 0 0;
+        padding: 0;
+        min-width: 0;
+        width: 24px;
+        height: 24px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        vertical-align: middle;
+      "
+      (click)="onCarouselClose()"
+      aria-label="Back"
+    >
+      <cds-icon shape="angle" direction="left" size="24"></cds-icon>
+    </button>
+    <span>Porsche 911 – Images</span>
+  </h3>
+
+  <div class="modal-body" style="padding: 0; overflow: hidden; display: flex; flex-direction: column">
+    <!-- Static gallery view -->
+    <div *ngIf="!showCarousel()" style="padding: 1rem">
+      <clr-image-gallery
+        [images]="images"
+        [productName]="'Porsche 911'"
+        [spotlightSize]="284"
+        [useBuiltInModal]="false"
+        (galleryOpen)="onGalleryOpen($event)"
+      ></clr-image-gallery>
+    </div>
+
+    <!-- Carousel replaces modal body (header hidden – Clarity modal provides title + close) -->
+    <clr-image-carousel
+      *ngIf="showCarousel()"
+      [images]="images"
+      [productName]="'Porsche 911'"
+      [initialIndex]="carouselIndex()"
+      [hideHeader]="true"
+      (closeCarousel)="onCarouselClose()"
+      style="flex: 1; min-height: 0; display: flex; flex-direction: column"
+    ></clr-image-carousel>
+  </div>
+</clr-modal>

--- a/src/dev/src/app/image-gallery/image-gallery-in-modal.demo.html
+++ b/src/dev/src/app/image-gallery/image-gallery-in-modal.demo.html
@@ -5,9 +5,12 @@
 -->
 
 <h2>Image Gallery in Modal Demo</h2>
+
+<!-- ── Fixed size ─────────────────────────────────────────────────────────── -->
+<h3>Fixed image size (<code>[imageSize]="400"</code>)</h3>
 <p>
   The gallery is embedded inside a Clarity modal with <code>[useBuiltInModal]="false"</code>. Clicking an image replaces
-  the modal content with the carousel instead of opening a nested modal.
+  the modal content with the carousel instead of opening a nested modal. The carousel uses explicit pixel sizes.
 </p>
 
 <button class="btn btn-primary" (click)="openModal()">Open Modal</button>
@@ -58,6 +61,63 @@
       [thumbnailSize]="48"
       [hideHeader]="true"
       (closeCarousel)="onCarouselClose()"
+      style="flex: 1; min-height: 0; display: flex; flex-direction: column"
+    ></clr-image-carousel>
+  </div>
+</clr-modal>
+
+<!-- ── Auto size ──────────────────────────────────────────────────────────── -->
+<h3 style="margin-top: 2rem">Auto size (no <code>imageSize</code> / <code>thumbnailSize</code>)</h3>
+<p>
+  Same pattern but without specifying any size inputs. The carousel automatically fills the available modal space. The
+  library adds the necessary flex fixes to the Clarity modal internals without any extra configuration.
+</p>
+
+<button class="btn btn-primary" (click)="openAutoModal()">Open Modal (auto size)</button>
+
+<clr-modal [clrModalOpen]="autoModalOpen()" (clrModalOpenChange)="$event ? null : onAutoModalClose()" clrModalSize="lg">
+  <h3 class="modal-title">
+    <button
+      *ngIf="showAutoCarousel()"
+      class="btn btn-icon btn-link"
+      style="
+        margin: 0 4px 0 0;
+        padding: 0;
+        min-width: 0;
+        width: 24px;
+        height: 24px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        vertical-align: middle;
+      "
+      (click)="onAutoCarouselClose()"
+      aria-label="Back"
+    >
+      <cds-icon shape="angle" direction="left" size="24"></cds-icon>
+    </button>
+    <span>Porsche 911 – Images (auto size)</span>
+  </h3>
+
+  <div class="modal-body" style="padding: 0; overflow: hidden; display: flex; flex-direction: column">
+    <!-- Static gallery view – no spotlightSize specified -->
+    <div *ngIf="!showAutoCarousel()" style="padding: 1rem">
+      <clr-image-gallery
+        [images]="images"
+        [productName]="'Porsche 911'"
+        [useBuiltInModal]="false"
+        (galleryOpen)="onAutoGalleryOpen($event)"
+      ></clr-image-gallery>
+    </div>
+
+    <!-- Carousel – no imageSize or thumbnailSize specified -->
+    <clr-image-carousel
+      *ngIf="showAutoCarousel()"
+      [images]="images"
+      [productName]="'Porsche 911'"
+      [initialIndex]="autoCarouselIndex()"
+      [hideHeader]="true"
+      (closeCarousel)="onAutoCarouselClose()"
       style="flex: 1; min-height: 0; display: flex; flex-direction: column"
     ></clr-image-carousel>
   </div>

--- a/src/dev/src/app/image-gallery/image-gallery-in-modal.demo.html
+++ b/src/dev/src/app/image-gallery/image-gallery-in-modal.demo.html
@@ -54,6 +54,8 @@
       [images]="images"
       [productName]="'Porsche 911'"
       [initialIndex]="carouselIndex()"
+      [imageSize]="400"
+      [thumbnailSize]="48"
       [hideHeader]="true"
       (closeCarousel)="onCarouselClose()"
       style="flex: 1; min-height: 0; display: flex; flex-direction: column"

--- a/src/dev/src/app/image-gallery/image-gallery-in-modal.demo.ts
+++ b/src/dev/src/app/image-gallery/image-gallery-in-modal.demo.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Component, effect, signal, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { angleIcon, ClarityIcons } from '@cds/core/icon';
+import { ClrImageGalleryModule, ClrImageGalleryImage, ClrImageGalleryOpenEvent } from '@porscheinformatik/clr-addons';
+
+ClarityIcons.addIcons(angleIcon);
+
+@Component({
+  selector: 'clr-image-gallery-in-modal-demo',
+  templateUrl: './image-gallery-in-modal.demo.html',
+  imports: [CommonModule, ClarityModule, ClrImageGalleryModule],
+  encapsulation: ViewEncapsulation.None,
+  styles: [
+    `
+      body.gallery-modal-open .modal-body-wrapper {
+        max-height: none !important;
+        overflow: hidden !important;
+        display: flex;
+        flex-direction: column;
+      }
+      body.gallery-modal-open .modal-dialog {
+        display: flex;
+        flex-direction: column;
+        max-height: 92vh;
+      }
+      body.gallery-modal-open .modal-content-wrapper,
+      body.gallery-modal-open .modal-content {
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        min-height: 0;
+      }
+    `,
+  ],
+})
+export class ImageGalleryInModalDemo {
+  protected modalOpen = signal(false);
+  protected showCarousel = signal(false);
+  protected carouselIndex = signal(0);
+
+  protected images: ClrImageGalleryImage[] = Array.from({ length: 10 }, (_, i) => ({
+    src: `https://picsum.photos/seed/modal${i + 1}/800/600`,
+    alt: `Image ${i + 1}`,
+  }));
+
+  constructor() {
+    effect(() => {
+      if (this.modalOpen()) {
+        document.body.classList.add('gallery-modal-open');
+      } else {
+        document.body.classList.remove('gallery-modal-open');
+      }
+    });
+  }
+
+  protected openModal(): void {
+    this.showCarousel.set(false);
+    this.modalOpen.set(true);
+  }
+
+  protected onGalleryOpen(event: ClrImageGalleryOpenEvent): void {
+    this.carouselIndex.set(event.index);
+    this.showCarousel.set(true);
+  }
+
+  protected onCarouselClose(): void {
+    this.showCarousel.set(false);
+  }
+
+  protected onModalClose(): void {
+    this.showCarousel.set(false);
+    this.modalOpen.set(false);
+  }
+}

--- a/src/dev/src/app/image-gallery/image-gallery-in-modal.demo.ts
+++ b/src/dev/src/app/image-gallery/image-gallery-in-modal.demo.ts
@@ -44,6 +44,10 @@ export class ImageGalleryInModalDemo {
   protected showCarousel = signal(false);
   protected carouselIndex = signal(0);
 
+  protected autoModalOpen = signal(false);
+  protected showAutoCarousel = signal(false);
+  protected autoCarouselIndex = signal(0);
+
   protected images: ClrImageGalleryImage[] = Array.from({ length: 10 }, (_, i) => ({
     src: `https://picsum.photos/seed/modal${i + 1}/800/600`,
     alt: `Image ${i + 1}`,
@@ -76,5 +80,24 @@ export class ImageGalleryInModalDemo {
   protected onModalClose(): void {
     this.showCarousel.set(false);
     this.modalOpen.set(false);
+  }
+
+  protected openAutoModal(): void {
+    this.showAutoCarousel.set(false);
+    this.autoModalOpen.set(true);
+  }
+
+  protected onAutoGalleryOpen(event: ClrImageGalleryOpenEvent): void {
+    this.autoCarouselIndex.set(event.index);
+    this.showAutoCarousel.set(true);
+  }
+
+  protected onAutoCarouselClose(): void {
+    this.showAutoCarousel.set(false);
+  }
+
+  protected onAutoModalClose(): void {
+    this.showAutoCarousel.set(false);
+    this.autoModalOpen.set(false);
   }
 }

--- a/src/dev/src/app/image-gallery/image-gallery.demo.html
+++ b/src/dev/src/app/image-gallery/image-gallery.demo.html
@@ -30,6 +30,30 @@
       style="width: 80px"
     />
   </label>
+  <label style="display: flex; align-items: center; gap: 0.4rem; font-size: 0.85rem">
+    Carousel image size (px, 0 = auto):
+    <input
+      class="clr-input"
+      type="number"
+      min="0"
+      max="1200"
+      [ngModel]="carouselImageSize()"
+      (ngModelChange)="setCarouselImageSize($event)"
+      style="width: 80px"
+    />
+  </label>
+  <label style="display: flex; align-items: center; gap: 0.4rem; font-size: 0.85rem">
+    Carousel thumbnail size (px):
+    <input
+      class="clr-input"
+      type="number"
+      min="16"
+      max="200"
+      [ngModel]="carouselThumbnailSize()"
+      (ngModelChange)="setCarouselThumbnailSize($event)"
+      style="width: 80px"
+    />
+  </label>
 </div>
 
 <!-- 7 images (overflow indicator visible) -->
@@ -40,6 +64,8 @@
       [images]="images"
       [productName]="productName()"
       [spotlightSize]="spotlightSize()"
+      [carouselImageSize]="carouselImageSize()"
+      [carouselThumbnailSize]="carouselThumbnailSize()"
     ></clr-image-gallery>
   </div>
 </div>

--- a/src/dev/src/app/image-gallery/image-gallery.demo.html
+++ b/src/dev/src/app/image-gallery/image-gallery.demo.html
@@ -1,0 +1,69 @@
+<!--
+  Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+  This software is released under MIT license.
+  The full license information can be found in LICENSE in the root directory of this project.
+-->
+
+<h2>Image Gallery Demo</h2>
+
+<!-- Controls -->
+<div style="margin-bottom: 1.5rem; display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center">
+  <label style="display: flex; align-items: center; gap: 0.4rem; font-size: 0.85rem">
+    Product name:
+    <input
+      class="clr-input"
+      type="text"
+      [ngModel]="productName()"
+      (ngModelChange)="productName.set($event)"
+      style="width: 140px"
+    />
+  </label>
+  <label style="display: flex; align-items: center; gap: 0.4rem; font-size: 0.85rem">
+    Spotlight size (px):
+    <input
+      class="clr-input"
+      type="number"
+      min="100"
+      max="800"
+      [ngModel]="spotlightSize()"
+      (ngModelChange)="setSpotlightSize($event)"
+      style="width: 80px"
+    />
+  </label>
+</div>
+
+<!-- 7 images (overflow indicator visible) -->
+<div class="card" style="margin-bottom: 1.5rem">
+  <div class="card-header">7 images – last thumbnail shows overflow count</div>
+  <div class="card-block" style="padding: 1rem">
+    <clr-image-gallery
+      [images]="images"
+      [productName]="productName()"
+      [spotlightSize]="spotlightSize()"
+    ></clr-image-gallery>
+  </div>
+</div>
+
+<!-- 3 images (no overflow) -->
+<div class="card" style="margin-bottom: 1.5rem">
+  <div class="card-header">3 images – no overflow indicator</div>
+  <div class="card-block" style="padding: 1rem">
+    <clr-image-gallery
+      [images]="fewImages"
+      [productName]="'3-image set'"
+      [spotlightSize]="spotlightSize()"
+    ></clr-image-gallery>
+  </div>
+</div>
+
+<!-- Single image -->
+<div class="card">
+  <div class="card-header">Single image – no thumbnail row</div>
+  <div class="card-block" style="padding: 1rem">
+    <clr-image-gallery
+      [images]="singleImage"
+      [productName]="'Single image'"
+      [spotlightSize]="spotlightSize()"
+    ></clr-image-gallery>
+  </div>
+</div>

--- a/src/dev/src/app/image-gallery/image-gallery.demo.ts
+++ b/src/dev/src/app/image-gallery/image-gallery.demo.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ClrImageGalleryModule, ClrImageGalleryImage } from '@porscheinformatik/clr-addons';
+
+@Component({
+  selector: 'clr-image-gallery-demo',
+  templateUrl: './image-gallery.demo.html',
+  imports: [CommonModule, FormsModule, ClrImageGalleryModule],
+})
+export class ImageGalleryDemo {
+  protected readonly productName = signal('Porsche 911');
+  protected readonly spotlightSize = signal(400);
+
+  protected images: ClrImageGalleryImage[] = [
+    { src: 'https://picsum.photos/seed/car1/800/600', alt: 'Car image 1' },
+    { src: 'https://picsum.photos/seed/car2/800/600', alt: 'Car image 2' },
+    { src: 'https://picsum.photos/seed/car3/800/600', alt: 'Car image 3' },
+    { src: 'https://picsum.photos/seed/car4/800/600', alt: 'Car image 4' },
+    { src: 'https://picsum.photos/seed/car5/800/600', alt: 'Car image 5' },
+    { src: 'https://picsum.photos/seed/car6/800/600', alt: 'Car image 6' },
+    { src: 'https://picsum.photos/seed/car7/800/600', alt: 'Car image 7' },
+  ];
+
+  protected fewImages: ClrImageGalleryImage[] = [
+    { src: 'https://picsum.photos/seed/few1/800/600', alt: 'Image 1' },
+    { src: 'https://picsum.photos/seed/few2/800/600', alt: 'Image 2' },
+    { src: 'https://picsum.photos/seed/few3/800/600', alt: 'Image 3' },
+  ];
+
+  protected singleImage: ClrImageGalleryImage[] = [
+    { src: 'https://picsum.photos/seed/single/800/600', alt: 'Single image' },
+  ];
+
+  setSpotlightSize(val: string): void {
+    const n = Number.parseInt(val);
+    if (!Number.isNaN(n) && n > 0) {
+      this.spotlightSize.set(n);
+    }
+  }
+}

--- a/src/dev/src/app/image-gallery/image-gallery.demo.ts
+++ b/src/dev/src/app/image-gallery/image-gallery.demo.ts
@@ -17,15 +17,10 @@ export class ImageGalleryDemo {
   protected readonly productName = signal('Porsche 911');
   protected readonly spotlightSize = signal(400);
 
-  protected images: ClrImageGalleryImage[] = [
-    { src: 'https://picsum.photos/seed/car1/800/600', alt: 'Car image 1' },
-    { src: 'https://picsum.photos/seed/car2/800/600', alt: 'Car image 2' },
-    { src: 'https://picsum.photos/seed/car3/800/600', alt: 'Car image 3' },
-    { src: 'https://picsum.photos/seed/car4/800/600', alt: 'Car image 4' },
-    { src: 'https://picsum.photos/seed/car5/800/600', alt: 'Car image 5' },
-    { src: 'https://picsum.photos/seed/car6/800/600', alt: 'Car image 6' },
-    { src: 'https://picsum.photos/seed/car7/800/600', alt: 'Car image 7' },
-  ];
+  protected images: ClrImageGalleryImage[] = Array.from({ length: 30 }, (_, i) => ({
+    src: `https://picsum.photos/seed/car${i + 1}/800/600`,
+    alt: `Car image ${i + 1}`,
+  }));
 
   protected fewImages: ClrImageGalleryImage[] = [
     { src: 'https://picsum.photos/seed/few1/800/600', alt: 'Image 1' },

--- a/src/dev/src/app/image-gallery/image-gallery.demo.ts
+++ b/src/dev/src/app/image-gallery/image-gallery.demo.ts
@@ -14,28 +14,40 @@ import { ClrImageGalleryModule, ClrImageGalleryImage } from '@porscheinformatik/
   imports: [CommonModule, FormsModule, ClrImageGalleryModule],
 })
 export class ImageGalleryDemo {
-  protected readonly productName = signal('Porsche 911');
-  protected readonly spotlightSize = signal(400);
+  readonly productName = signal('Porsche 911');
+  readonly spotlightSize = signal(400);
+  readonly carouselImageSize = signal(0);
+  readonly carouselThumbnailSize = signal(64);
 
-  protected images: ClrImageGalleryImage[] = Array.from({ length: 30 }, (_, i) => ({
+  images: ClrImageGalleryImage[] = Array.from({ length: 30 }, (_, i) => ({
     src: `https://picsum.photos/seed/car${i + 1}/800/600`,
     alt: `Car image ${i + 1}`,
   }));
 
-  protected fewImages: ClrImageGalleryImage[] = [
+  fewImages: ClrImageGalleryImage[] = [
     { src: 'https://picsum.photos/seed/few1/800/600', alt: 'Image 1' },
     { src: 'https://picsum.photos/seed/few2/800/600', alt: 'Image 2' },
     { src: 'https://picsum.photos/seed/few3/800/600', alt: 'Image 3' },
   ];
 
-  protected singleImage: ClrImageGalleryImage[] = [
-    { src: 'https://picsum.photos/seed/single/800/600', alt: 'Single image' },
-  ];
+  singleImage: ClrImageGalleryImage[] = [{ src: 'https://picsum.photos/seed/single/800/600', alt: 'Single image' }];
 
   setSpotlightSize(val: string): void {
     const n = Number.parseInt(val);
     if (!Number.isNaN(n) && n > 0) {
       this.spotlightSize.set(n);
+    }
+  }
+
+  setCarouselImageSize(val: string): void {
+    const n = Number.parseInt(val);
+    this.carouselImageSize.set(!Number.isNaN(n) && n > 0 ? n : 0);
+  }
+
+  setCarouselThumbnailSize(val: string): void {
+    const n = Number.parseInt(val);
+    if (!Number.isNaN(n) && n > 0) {
+      this.carouselThumbnailSize.set(n);
     }
   }
 }

--- a/website/src/app/documentation/demos/image-gallery/image-gallery.demo.html
+++ b/website/src/app/documentation/demos/image-gallery/image-gallery.demo.html
@@ -1,0 +1,78 @@
+<!--
+  ~ Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<clr-doc-wrapper [title]="title">
+  <article>
+    <h5 class="component-summary">
+      The Image Gallery displays a set of images in a compact static view and allows the user to browse them in a full
+      carousel modal.
+    </h5>
+
+    <div id="design-guidelines">
+      <h3>Summary of Options</h3>
+      <table class="table">
+        <thead>
+          <tr>
+            <th class="left">Input</th>
+            <th class="left clr-hidden-xs-down">Type</th>
+            <th class="clr-hidden-xs-down">Default</th>
+            <th class="left">Effect</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="left">
+              <b>images</b>
+              <div class="clr-hidden-sm-up">Type: ClrImageGalleryImage[]</div>
+              <div class="clr-hidden-sm-up">Default: []</div>
+            </td>
+            <td class="left clr-hidden-xs-down">ClrImageGalleryImage[]</td>
+            <td class="clr-hidden-xs-down">[]</td>
+            <td class="left">Array of image objects with <code>src</code> and optional <code>alt</code> fields.</td>
+          </tr>
+          <tr>
+            <td class="left">
+              <b>productName</b>
+              <div class="clr-hidden-sm-up">Type: string</div>
+              <div class="clr-hidden-sm-up">Default: ''</div>
+            </td>
+            <td class="left clr-hidden-xs-down">string</td>
+            <td class="clr-hidden-xs-down">''</td>
+            <td class="left">Title shown in the carousel modal header.</td>
+          </tr>
+          <tr>
+            <td class="left">
+              <b>spotlightSize</b>
+              <div class="clr-hidden-sm-up">Type: number</div>
+              <div class="clr-hidden-sm-up">Default: 400</div>
+            </td>
+            <td class="left clr-hidden-xs-down">number</td>
+            <td class="clr-hidden-xs-down">400</td>
+            <td class="left">
+              Pixel size of the spotlight square in the static view. Thumbnails scale automatically to
+              <code>spotlightSize / 4</code>.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div id="code-examples">
+      <h3 id="examples">Code &amp; Examples</h3>
+
+      <h4>Default (7 images, spotlight 400 px)</h4>
+      <p>
+        Click the gallery to open the carousel modal. Use the arrow buttons or the thumbnail strip to navigate. Close
+        via the ✕ button or by clicking outside the modal.
+      </p>
+      <clr-image-gallery [images]="images" [productName]="'Porsche 911'" [spotlightSize]="400"></clr-image-gallery>
+      <clr-code-snippet [clrCode]="htmlExample"></clr-code-snippet>
+
+      <h4>Smaller spotlight (200 px)</h4>
+      <clr-image-gallery [images]="images" [productName]="'Porsche 911'" [spotlightSize]="200"></clr-image-gallery>
+    </div>
+  </article>
+</clr-doc-wrapper>

--- a/website/src/app/documentation/demos/image-gallery/image-gallery.demo.module.ts
+++ b/website/src/app/documentation/demos/image-gallery/image-gallery.demo.module.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { RouterModule } from '@angular/router';
+
+import { ImageGalleryDemo } from './image-gallery.demo';
+import { DocWrapperModule } from '../_doc-wrapper/doc-wrapper.module';
+import { UtilsModule } from '../../../utils/utils.module';
+import { ClrAddonsModule } from '@porscheinformatik/clr-addons';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ClarityModule,
+    UtilsModule,
+    DocWrapperModule,
+    RouterModule.forChild([{ path: '', component: ImageGalleryDemo }]),
+    ClrAddonsModule,
+  ],
+  declarations: [ImageGalleryDemo],
+  exports: [ImageGalleryDemo],
+})
+export class ImageGalleryDemoModule {}

--- a/website/src/app/documentation/demos/image-gallery/image-gallery.demo.ts
+++ b/website/src/app/documentation/demos/image-gallery/image-gallery.demo.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { Component } from '@angular/core';
+import { ClrImageGalleryImage } from '@porscheinformatik/clr-addons';
+import { ClarityDocComponent } from '../clarity-doc';
+
+const HTML_EXAMPLE = `
+<clr-image-gallery
+  [images]="images"
+  [productName]="'Porsche 911'"
+  [spotlightSize]="400">
+</clr-image-gallery>
+`;
+
+@Component({
+  selector: 'clr-image-gallery-demo',
+  templateUrl: './image-gallery.demo.html',
+  host: {
+    '[class.content-area]': 'true',
+    '[class.dox-content-panel]': 'true',
+  },
+  standalone: false,
+})
+export class ImageGalleryDemo extends ClarityDocComponent {
+  htmlExample = HTML_EXAMPLE;
+
+  images: ClrImageGalleryImage[] = [
+    { src: 'https://picsum.photos/seed/car1/800/600', alt: 'Car image 1' },
+    { src: 'https://picsum.photos/seed/car2/800/600', alt: 'Car image 2' },
+    { src: 'https://picsum.photos/seed/car3/800/600', alt: 'Car image 3' },
+    { src: 'https://picsum.photos/seed/car4/800/600', alt: 'Car image 4' },
+    { src: 'https://picsum.photos/seed/car5/800/600', alt: 'Car image 5' },
+    { src: 'https://picsum.photos/seed/car6/800/600', alt: 'Car image 6' },
+    { src: 'https://picsum.photos/seed/car7/800/600', alt: 'Car image 7' },
+  ];
+
+  constructor() {
+    super('image-gallery');
+  }
+}

--- a/website/src/app/documentation/documentation-routing.module.ts
+++ b/website/src/app/documentation/documentation-routing.module.ts
@@ -294,6 +294,14 @@ const documentationRoutes: Routes = [
           browserTitle: 'Keyboard Navigation',
         },
       },
+      {
+        path: 'image-gallery',
+        loadChildren: () =>
+          import('./demos/image-gallery/image-gallery.demo.module').then(m => m.ImageGalleryDemoModule),
+        data: {
+          browserTitle: 'Image Gallery',
+        },
+      },
     ],
   },
 ];

--- a/website/src/settings/componentlist.json
+++ b/website/src/settings/componentlist.json
@@ -81,6 +81,12 @@
       "type": "component"
     },
     {
+      "url": "image-gallery",
+      "text": "Image Gallery",
+      "type": "component",
+      "isNew": true
+    },
+    {
       "url": "icon-avatar",
       "text": "Icon avatar",
       "type": "component"


### PR DESCRIPTION
This PR adds a two new components:
* `clr-image-gallery` - this is the main component that displays a static mosaic of images where one is highlighted and the rest are displayed in a thumbnail strip at the bottom. Clicking on any image will open up a modal that displays the second component
<img width="471" height="572" alt="image" src="https://github.com/user-attachments/assets/438bd39b-6925-4001-bcac-5f44f7c8907d" />

* `clr-image-carousel` - this is a secondary component that displays a carousel of images that can be cycled through via arrow keys, left/right buttons, or by clicking on an image in the thumbnail strip.
<img width="869" height="994" alt="image" src="https://github.com/user-attachments/assets/2ef3b66e-f617-4ab3-99ac-7af18c628537" />


The default behavior of the `clr-image-gallery` is to spawn a built-in modal with the carousel, but optionally `[useBuiltInModal]="false"` can be specified and then `clr-image-carousel` should then be added manually. The use case for this is when the image gallery is already part of a modal and the desired approach is to replace the current modal content instead of spawning a new modal on top.