### PR TITLE
Add autoscaling and manual setting of y-axis min value for line-charts

### DIFF
--- a/src/clr-addons/charts/line-chart/line-chart.component.ts
+++ b/src/clr-addons/charts/line-chart/line-chart.component.ts
@@ -4,6 +4,7 @@ import {
   format as d3format,
   line as d3line,
   max as d3max,
+  min as d3min,
   scaleLinear as d3scaleLinear,
   ScaleLinear,
   scalePoint as d3scalePoint,
@@ -56,6 +57,9 @@ export class LineChartComponent extends ChartBase<LineChartSelectedPoint> implem
   public readonly xAxisLabel = input<string>('');
   /** Optional label rendered rotated to the left of the Y axis. */
   public readonly yAxisLabel = input<string>('');
+
+  public readonly yMin = input<number>(0);
+  public readonly autoscaleYAxis = input<boolean>(false);
 
   public readonly valueClicked = output<XYChartValue>();
 
@@ -125,7 +129,8 @@ export class LineChartComponent extends ChartBase<LineChartSelectedPoint> implem
 
     const x = d3scalePoint<string>().domain(xKeys).range([0, width]).padding(0.5);
     const maxY = d3max(this.series().flatMap(s => s.data.map(d => d.value))) ?? 0;
-    const y = d3scaleLinear().domain([0, maxY]).nice().range([height, 0]);
+    const minY = this.autoscaleYAxis() ? d3min(this.series().flatMap(s => s.data.map(d => d.value))) ?? 0 : this.yMin();
+    const y = d3scaleLinear().domain([minY, maxY]).nice().range([height, 0]);
 
     const g = this.svg
       .attr('width', width)

--- a/src/dev/src/app/line-chart/line-chart.demo.html
+++ b/src/dev/src/app/line-chart/line-chart.demo.html
@@ -25,6 +25,20 @@
       style="width: 130px"
     />
   </label>
+  <button class="btn btn-outline" (click)="toggleAutoscaleYAxis()">
+    Toggle Y-Axis Autoscaling (current: {{ autoscaleYAxis() }})
+  </button>
+  <label style="display: flex; align-items: center; gap: 0.25rem; font-size: 0.85rem">
+    Min value for y-axis:
+    <input
+      class="clr-input"
+      type="number"
+      step="10"
+      [ngModel]="yMin()"
+      (ngModelChange)="yMin.set($event)"
+      style="width: 130px"
+    />
+  </label>
 </div>
 
 @if (lastClicked()) {
@@ -51,6 +65,8 @@
         [showValues]="showValues()"
         [showExportButton]="showExportButton()"
         [exportFilename]="exportFilename()"
+        [yMin]="yMin()"
+        [autoscaleYAxis]="autoscaleYAxis()"
         (valueClicked)="onValueClicked($event)"
         style="display: block; width: 100%; height: 100%"
       ></clr-line-chart>

--- a/src/dev/src/app/line-chart/line-chart.demo.ts
+++ b/src/dev/src/app/line-chart/line-chart.demo.ts
@@ -24,6 +24,8 @@ export class LineChartDemo {
   protected readonly showValues = signal(false);
   protected readonly showExportButton = signal(false);
   protected readonly lastClicked = signal<LineChartValue | undefined>(undefined);
+  protected readonly yMin = signal(0);
+  protected readonly autoscaleYAxis = signal(false);
 
   protected singleSeries: LineChartSeries[] = [
     {
@@ -79,5 +81,9 @@ export class LineChartDemo {
 
   public onValueClicked(value: LineChartValue): void {
     this.lastClicked.set(value);
+  }
+
+  public toggleAutoscaleYAxis(): void {
+    this.autoscaleYAxis.set(!this.autoscaleYAxis());
   }
 }

--- a/website/src/app/documentation/demos/charts/charts.demo.html
+++ b/website/src/app/documentation/demos/charts/charts.demo.html
@@ -386,6 +386,18 @@
           <td class="left">''</td>
           <td class="left">Optional axis description labels.</td>
         </tr>
+        <tr>
+          <td class="left"><code>autoscaleYAxis</code></td>
+          <td class="left">boolean</td>
+          <td class="left">false</td>
+          <td class="left">Autoscale Y-Axis depending on the smallest value in series</td>
+        </tr>
+        <tr>
+          <td class="left"><code>yMin</code></td>
+          <td class="left">number</td>
+          <td class="left">0</td>
+          <td class="left">If autoscale=false, this can be used to manually set the min value of the Y-Axis</td>
+        </tr>
       </tbody>
     </table>
 
@@ -440,6 +452,27 @@
       <clr-line-chart
         [series]="lineSeries"
         [showLegend]="true"
+        xAxisLabel="Month"
+        yAxisLabel="Revenue (€)"
+        style="display: block; width: 100%; height: 100%"
+      ></clr-line-chart>
+    </div>
+
+    <h3>Example – Autoscaling Y-Axis (<code>autoscaleYAxis</code>)</h3>
+    <p>
+      Setting <code class="clr-code">[autoscaleYAxis]="true"</code> scales the y-axis dynamically to the range of the
+      provide data points.
+    </p>
+    <clr-code-snippet
+      clrLanguage="html"
+      [clrCode]='&apos;<clr-line-chart\n  [series]="lineSeries"\n  [autoscaleYAxis]="true"\n  xAxisLabel="Month"\n  yAxisLabel="Value"\n  style="display:block;width:100%;height:300px;"\n></clr-line-chart>&apos;'
+    >
+    </clr-code-snippet>
+    <div style="height: 320px; width: 100%; margin-top: 1rem">
+      <clr-line-chart
+        [series]="lineSeries"
+        [showLegend]="true"
+        [autoscaleYAxis]="true"
         xAxisLabel="Month"
         yAxisLabel="Value"
         style="display: block; width: 100%; height: 100%"


### PR DESCRIPTION
Adds 2 new inputs for line-charts.
- autoscaleYAxis:
Autoscale y-axis depending on the smallest value in series
- yMin:
If autoscale=false, this can be used to manually set the min value of the Y-Axis