### PR TITLE
[C3DEV-603168] Fixes summary area initial row state

### DIFF
--- a/src/clr-addons/summary-area/summary-area/summary-area.html
+++ b/src/clr-addons/summary-area/summary-area/summary-area.html
@@ -10,7 +10,7 @@
     [class.is-active]="!isCollapsed() && (hasLoading || hasError || hasWarning)"
     [class.is-error]="hasError"
     [class.is-warning]="hasWarning"
-    [style.--rows]="currentRows"
+    [style.--rows]="currentRows()"
     [attr.aria-hidden]="isCollapsed() || !(hasLoading || hasError || hasWarning) ? 'true' : 'false'"
     [attr.inert]="isCollapsed() || !(hasLoading || hasError || hasWarning) ? '' : null"
   >
@@ -45,9 +45,9 @@
           <clr-alert-item>
             @if (warningLinkText && warningClick) {
             <span class="alert-text">{{ warningText }}</span>
-            <span class="alert-action" (click)="warningClick()" (keydown.enter)="warningClick()"
-              >{{ warningLinkText }}</span
-            >
+            <span class="alert-action" (click)="warningClick()" (keydown.enter)="warningClick()">
+              {{ warningLinkText }}
+            </span>
             } @else if (warningClick) {
             <span class="alert-action" (click)="warningClick()" (keydown.enter)="warningClick()"
               >{{ warningText }}</span
@@ -70,7 +70,7 @@
   >
     <div class="summary-area-panel__body">
       <div class="summary-area-container">
-        <div class="summary-grid" [style.--columns]="currentColumns" [style.--rows]="currentRows">
+        <div class="summary-grid" [style.--columns]="currentColumns" [style.--rows]="currentRows()">
           <ng-container *ngFor="let item of visibleItems">
             <ng-container *ngTemplateOutlet="item.template"></ng-container>
           </ng-container>

--- a/src/clr-addons/summary-area/summary-area/summary-area.ts
+++ b/src/clr-addons/summary-area/summary-area/summary-area.ts
@@ -286,7 +286,7 @@ export class ClrSummaryArea implements OnInit, AfterViewInit, OnDestroy {
       // If enough space, use as many columns as needed for the row constraint
       // If not enough space, reduce columns and allow more rows per column
       this.currentColumns = Math.max(1, Math.min(neededColumns, maxColumnsByWidth)) as ClrSummaryAreaColumns;
-      this.currentRows.update(() => Math.ceil(itemCount / this.currentColumns) as ClrSummaryAreaRows);
+      this.currentRows.set(Math.ceil(itemCount / this.currentColumns) as ClrSummaryAreaRows);
       this.cdr.detectChanges();
     }
   }

--- a/src/clr-addons/summary-area/summary-area/summary-area.ts
+++ b/src/clr-addons/summary-area/summary-area/summary-area.ts
@@ -14,6 +14,7 @@ import {
   HostListener,
   inject,
   input,
+  linkedSignal,
   OnDestroy,
   OnInit,
   QueryList,
@@ -26,10 +27,10 @@ import { ClarityModule } from '@clr/angular';
 import { ClrSummaryAreaStateService, defaultSummaryAreaCollapsedKey } from './summary-area-state.service';
 import {
   ClrSummaryAreaColumns,
-  ClrSummaryAreaRows,
   ClrSummaryAreaError,
-  ClrSummaryAreaWarning,
   ClrSummaryAreaLoading,
+  ClrSummaryAreaRows,
+  ClrSummaryAreaWarning,
 } from './summary-area.model';
 
 @Component({
@@ -51,7 +52,7 @@ export class ClrSummaryArea implements OnInit, AfterViewInit, OnDestroy {
   public loading = input<ClrSummaryAreaLoading | undefined>();
 
   public currentColumns: ClrSummaryAreaColumns = 5;
-  public currentRows: ClrSummaryAreaRows = this.rows();
+  public currentRows = linkedSignal((): ClrSummaryAreaRows => this.rows());
   public panelHeight: string = '0px';
   public loadingPanelHeight: string = '0px';
   public loadingVisible = false;
@@ -285,7 +286,7 @@ export class ClrSummaryArea implements OnInit, AfterViewInit, OnDestroy {
       // If enough space, use as many columns as needed for the row constraint
       // If not enough space, reduce columns and allow more rows per column
       this.currentColumns = Math.max(1, Math.min(neededColumns, maxColumnsByWidth)) as ClrSummaryAreaColumns;
-      this.currentRows = Math.ceil(itemCount / this.currentColumns) as ClrSummaryAreaRows;
+      this.currentRows.update(() => Math.ceil(itemCount / this.currentColumns) as ClrSummaryAreaRows);
       this.cdr.detectChanges();
     }
   }
@@ -382,7 +383,7 @@ export class ClrSummaryArea implements OnInit, AfterViewInit, OnDestroy {
     }
 
     // For loading state, calculate based on current rows
-    const gridHeight = this.currentRows * itemHeight + (this.currentRows - 1) * rowGap;
+    const gridHeight = this.currentRows() * itemHeight + (this.currentRows() - 1) * rowGap;
     return gridHeight + gridPadding;
   }
 


### PR DESCRIPTION
**Problem:**
The input value for the number of rows is not respected if there are not items in the summary area.
This applied to the following summary:
- data is loaded asynchonosly
- summary number of rows is set to 2
- summary loading state is connected to data loading

results in the height of the summary area starting as 3 rows and jumping to 2 rows when the data is loaded.
This is because the `currentRows` field is initialized with the default value of the `rows` input and only updated if there are item child elements in the summary area component.

**Fix:**
- Fixed by refactoring the `currentRows` field to a `linkedSignal` and connecting it to the `rows` input of the component.