### PR TITLE
Adds support for native a (link) element behavior for summary item values in summary area component

### DIFF
--- a/src/clr-addons/summary-area/summary-item-value/summary-item-value.html
+++ b/src/clr-addons/summary-area/summary-item-value/summary-item-value.html
@@ -1,4 +1,17 @@
-@if (icon() !== undefined && icon() !== null && icon() !== '') { @if (hasClickHandler) { @if (tooltip()) {
+@if (icon() !== undefined && icon() !== null && icon() !== '') { @if (href()) { @if (tooltip()) {
+<clr-tooltip>
+  <a clrTooltipTrigger class="value-icon-link" [href]="href()" [attr.target]="target() ?? null" (click)="handleClick()">
+    <cds-icon [shape]="icon()" class="value-icon value-link"></cds-icon>
+  </a>
+  <clr-tooltip-content [clrSize]="tooltipSize" [clrPosition]="tooltipPosition" *clrIfOpen>
+    {{ tooltip() }}</clr-tooltip-content
+  >
+</clr-tooltip>
+} @else {
+<a class="value-icon-link" [href]="href()" [attr.target]="target() ?? null" (click)="handleClick()">
+  <cds-icon [shape]="icon()" class="value-icon value-link"></cds-icon>
+</a>
+} } @else if (hasClickHandler) { @if (tooltip()) {
 <clr-tooltip>
   <cds-icon
     clrTooltipTrigger
@@ -29,7 +42,27 @@
 </clr-tooltip>
 } @else {
 <cds-icon [shape]="icon()" class="value-icon value-icon-neutral"></cds-icon>
-} } } @else if (value() !== undefined && value() !== null && value() !== '') { @if (hasClickHandler) {
+} } } @else if (value() !== undefined && value() !== null && value() !== '') { @if (href()) { @if (effectiveTooltip) {
+<clr-tooltip>
+  <a
+    #valueElement
+    class="value value-link"
+    clrTooltipTrigger
+    [href]="href()"
+    [attr.target]="target() ?? null"
+    (click)="handleClick()"
+  >
+    {{ value() }}
+  </a>
+  <clr-tooltip-content [clrSize]="tooltipSize" [clrPosition]="tooltipPosition" *clrIfOpen>
+    {{ effectiveTooltip }}</clr-tooltip-content
+  >
+</clr-tooltip>
+} @else {
+<a #valueElement class="value value-link" [href]="href()" [attr.target]="target() ?? null" (click)="handleClick()">
+  {{ value() }}
+</a>
+} } @else if (hasClickHandler) {
 <clr-tooltip>
   <span
     #valueElement

--- a/src/clr-addons/summary-area/summary-item-value/summary-item-value.scss
+++ b/src/clr-addons/summary-area/summary-item-value/summary-item-value.scss
@@ -34,6 +34,28 @@ cds-icon {
   flex-shrink: 0;
 }
 
+// Wrapper <a> used when an icon has an href. Resets browser anchor defaults so
+// only the inner cds-icon carries the visual link styling.
+.value-icon-link {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+  cursor: pointer;
+
+  cds-icon {
+    color: var(--cds-alias-typography-link-color);
+  }
+}
+
+.value-icon-link:hover cds-icon,
+.value-icon-link:focus cds-icon {
+  color: var(--cds-alias-typography-link-color-hover);
+}
+
+.value-icon-link:visited cds-icon {
+  color: var(--cds-alias-typography-link-color-visited);
+}
+
 .value-icon {
   height: 20px;
   width: 20px;

--- a/src/clr-addons/summary-area/summary-item-value/summary-item-value.spec.ts
+++ b/src/clr-addons/summary-area/summary-item-value/summary-item-value.spec.ts
@@ -295,7 +295,7 @@ describe('SummaryItemValue', () => {
       fixture.detectChanges();
 
       const anchorElement = fixture.debugElement.query(By.css('a.value-icon-link'));
-      anchorElement.nativeElement.click();
+      anchorElement.triggerEventHandler('click', new MouseEvent('click'));
       expect(clickSpy).toHaveBeenCalled();
     });
 
@@ -400,7 +400,7 @@ describe('SummaryItemValue', () => {
       fixture.detectChanges();
 
       const anchorElement = fixture.debugElement.query(By.css('a.value.value-link'));
-      anchorElement.nativeElement.click();
+      anchorElement.triggerEventHandler('click', new MouseEvent('click'));
       expect(clickSpy).toHaveBeenCalled();
     });
 
@@ -413,7 +413,7 @@ describe('SummaryItemValue', () => {
       fixture.detectChanges();
 
       const anchorElement = fixture.debugElement.query(By.css('a.value.value-link'));
-      anchorElement.nativeElement.click();
+      anchorElement.triggerEventHandler('click', new MouseEvent('click'));
       expect(clickSpy).not.toHaveBeenCalled();
     });
 

--- a/src/clr-addons/summary-area/summary-item-value/summary-item-value.spec.ts
+++ b/src/clr-addons/summary-area/summary-item-value/summary-item-value.spec.ts
@@ -13,6 +13,8 @@ import { ClarityModule } from '@clr/angular';
       [clickable]="clickable"
       (clicked)="clickedFn()"
       [tooltip]="tooltip"
+      [href]="href"
+      [target]="target"
     >
       @if (projectedContent) {
       <span>{{ projectedContent }}</span>
@@ -30,6 +32,8 @@ class TestHostComponent {
   clickable: boolean | undefined;
   clickedFn: () => void;
   projectedContent: string | undefined;
+  href: string | undefined;
+  target: string | undefined;
 }
 
 @Component({
@@ -259,6 +263,53 @@ describe('SummaryItemValue', () => {
       const iconElement = fixture.debugElement.query(By.css('cds-icon.value-icon-neutral'));
       expect(iconElement).toBeTruthy();
     });
+
+    it('should render icon wrapped in <a> when href is provided', () => {
+      hostComponent.icon = 'pencil';
+      hostComponent.href = 'https://example.com';
+      fixture.detectChanges();
+
+      const anchorElement = fixture.debugElement.query(By.css('a.value-icon-link'));
+      const iconElement = fixture.debugElement.query(By.css('a.value-icon-link cds-icon'));
+      expect(anchorElement).toBeTruthy();
+      expect(anchorElement.attributes['href']).toBe('https://example.com');
+      expect(iconElement).toBeTruthy();
+    });
+
+    it('should set target on icon <a> wrapper when target is provided', () => {
+      hostComponent.icon = 'pencil';
+      hostComponent.href = 'https://example.com';
+      hostComponent.target = '_blank';
+      fixture.detectChanges();
+
+      const anchorElement = fixture.debugElement.query(By.css('a.value-icon-link'));
+      expect(anchorElement.attributes['target']).toBe('_blank');
+    });
+
+    it('should emit clicked when icon href and clickable are both set', () => {
+      const clickSpy = jasmine.createSpy('clickedFn');
+      hostComponent.icon = 'pencil';
+      hostComponent.href = 'https://example.com';
+      hostComponent.clickable = true;
+      hostComponent.clickedFn = clickSpy;
+      fixture.detectChanges();
+
+      const anchorElement = fixture.debugElement.query(By.css('a.value-icon-link'));
+      anchorElement.nativeElement.click();
+      expect(clickSpy).toHaveBeenCalled();
+    });
+
+    it('should render tooltip on icon <a> wrapper when href and tooltip are both provided', () => {
+      hostComponent.icon = 'pencil';
+      hostComponent.href = 'https://example.com';
+      hostComponent.tooltip = 'Edit';
+      fixture.detectChanges();
+
+      const tooltipElement = fixture.debugElement.query(By.css('clr-tooltip'));
+      const anchorElement = fixture.debugElement.query(By.css('a.value-icon-link'));
+      expect(tooltipElement).toBeTruthy();
+      expect(anchorElement).toBeTruthy();
+    });
   });
 
   describe('value rendering', () => {
@@ -304,6 +355,89 @@ describe('SummaryItemValue', () => {
 
       const linkElement = fixture.debugElement.query(By.css('.value-link'));
       expect(linkElement).toBeFalsy();
+    });
+  });
+
+  describe('href / target rendering', () => {
+    it('should render an <a> element when href is provided', () => {
+      hostComponent.value = 'Link Value';
+      hostComponent.href = 'https://example.com';
+      fixture.detectChanges();
+
+      const anchorElement = fixture.debugElement.query(By.css('a.value.value-link'));
+      expect(anchorElement).toBeTruthy();
+      expect(anchorElement.attributes['href']).toBe('https://example.com');
+    });
+
+    it('should set target attribute on <a> when target is provided', () => {
+      hostComponent.value = 'Link Value';
+      hostComponent.href = 'https://example.com';
+      hostComponent.target = '_blank';
+      fixture.detectChanges();
+
+      const anchorElement = fixture.debugElement.query(By.css('a.value.value-link'));
+      expect(anchorElement).toBeTruthy();
+      expect(anchorElement.attributes['target']).toBe('_blank');
+    });
+
+    it('should not set target attribute when target is not provided', () => {
+      hostComponent.value = 'Link Value';
+      hostComponent.href = 'https://example.com';
+      hostComponent.target = undefined;
+      fixture.detectChanges();
+
+      const anchorElement = fixture.debugElement.query(By.css('a.value.value-link'));
+      expect(anchorElement).toBeTruthy();
+      expect(anchorElement.attributes['target']).toBeFalsy();
+    });
+
+    it('should emit clicked when href and clickable are both set and link is clicked', () => {
+      const clickSpy = jasmine.createSpy('clickedFn');
+      hostComponent.value = 'Link Value';
+      hostComponent.href = 'https://example.com';
+      hostComponent.clickable = true;
+      hostComponent.clickedFn = clickSpy;
+      fixture.detectChanges();
+
+      const anchorElement = fixture.debugElement.query(By.css('a.value.value-link'));
+      anchorElement.nativeElement.click();
+      expect(clickSpy).toHaveBeenCalled();
+    });
+
+    it('should not emit clicked when href is set but clickable is false', () => {
+      const clickSpy = jasmine.createSpy('clickedFn');
+      hostComponent.value = 'Link Value';
+      hostComponent.href = 'https://example.com';
+      hostComponent.clickable = false;
+      hostComponent.clickedFn = clickSpy;
+      fixture.detectChanges();
+
+      const anchorElement = fixture.debugElement.query(By.css('a.value.value-link'));
+      anchorElement.nativeElement.click();
+      expect(clickSpy).not.toHaveBeenCalled();
+    });
+
+    it('should render tooltip on <a> element when href and tooltip are both provided', () => {
+      hostComponent.value = 'Link Value';
+      hostComponent.href = 'https://example.com';
+      hostComponent.tooltip = 'Open link';
+      fixture.detectChanges();
+
+      const tooltipElement = fixture.debugElement.query(By.css('clr-tooltip'));
+      const anchorElement = fixture.debugElement.query(By.css('a.value.value-link'));
+      expect(tooltipElement).toBeTruthy();
+      expect(anchorElement).toBeTruthy();
+    });
+
+    it('should render <span> (not <a>) when href is not provided', () => {
+      hostComponent.value = 'Plain Value';
+      hostComponent.href = undefined;
+      fixture.detectChanges();
+
+      const anchorElement = fixture.debugElement.query(By.css('a.value'));
+      const spanElement = fixture.debugElement.query(By.css('span.value'));
+      expect(anchorElement).toBeFalsy();
+      expect(spanElement).toBeTruthy();
     });
   });
 

--- a/src/clr-addons/summary-area/summary-item-value/summary-item-value.ts
+++ b/src/clr-addons/summary-area/summary-item-value/summary-item-value.ts
@@ -40,6 +40,8 @@ export class ClrSummaryItemValue implements OnInit, AfterContentInit, AfterViewI
   public readonly icon = input<string | undefined>();
   public readonly tooltip = input<string | undefined>();
   public readonly clickable = input<boolean>(false);
+  public readonly href = input<string | undefined>();
+  public readonly target = input<string | undefined>();
   public readonly clicked = output<void>();
 
   public hasProjectedContent = false;

--- a/src/dev/src/app/summary-area/summary-area.demo.html
+++ b/src/dev/src/app/summary-area/summary-area.demo.html
@@ -21,12 +21,15 @@
     <clr-summary-item-value value="John Doe (with tooltip)" tooltip="Name: John Doe"></clr-summary-item-value>
   </clr-summary-item>
   <clr-summary-item label="Label3">
-    <clr-summary-item-value icon="color-palette"></clr-summary-item-value>
+    <!-- NOTE: Icon with href opens a link natively (supports right-click "Open in new tab") -->
     <clr-summary-item-value
-      value="Clarity Colors"
-      [clickable]="true"
-      (clicked)="goToClarityRoute()"
+      icon="color-palette"
+      href="https://clarity.design"
+      target="_blank"
+      tooltip="Open Clarity Design"
     ></clr-summary-item-value>
+    <clr-summary-item-value value="Clarity Colors" href="https://clarity.design" target="_blank">
+    </clr-summary-item-value>
   </clr-summary-item>
   <clr-summary-item label="Label4" [valueCopyable]="true">
     <clr-summary-item-value value="Text item1"></clr-summary-item-value>
@@ -76,23 +79,23 @@
   <clr-summary-item label="Two links13" [valueCopyable]="true" [editConfig]="{enabled: true, click: onEditClick}">
     <clr-summary-item-value
       [icon]="'wand'"
-      [clickable]="true"
-      (clicked)="goToIconsPage()"
+      href="/icons"
       [tooltip]="'navigate to /icons route'"
     ></clr-summary-item-value>
     <clr-summary-item-value
       value="Navigate internally"
-      [clickable]="true"
-      (clicked)="goToPagerRoute()"
+      href="/pager"
       [tooltip]="'navigate to /pager route'"
     ></clr-summary-item-value>
   </clr-summary-item>
   <clr-summary-item label="External link14" [valueCopyable]="true">
+    <!-- NOTE: Using href + target="_blank" opens the link natively in a new tab,
+       including support for right-click "Open in new tab" from the context menu -->
     <clr-summary-item-value
       value="External App Jump"
       tooltip="Navigate to external app"
-      [clickable]="true"
-      (clicked)="goToExternalApp()"
+      href="https://external-app.example.com"
+      target="_blank"
     ></clr-summary-item-value>
   </clr-summary-item>
   <clr-summary-item label="Long Text15" [valueCopyable]="true" [copyButtonTooltip]="'Click to copy complete long text'">

--- a/src/dev/src/app/summary-area/summary-area.demo.ts
+++ b/src/dev/src/app/summary-area/summary-area.demo.ts
@@ -3,8 +3,7 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import { Component, inject, OnInit, signal } from '@angular/core';
-import { Router } from '@angular/router';
+import { Component, OnInit, signal } from '@angular/core';
 import {
   ClrSummaryArea,
   ClrSummaryAreaError,
@@ -87,8 +86,6 @@ export class SummaryAreaDemo implements OnInit {
     alert('Handle warning clicked!');
   }
 
-  private readonly router: Router = inject(Router);
-
   public ngOnInit(): void {
     // Simulate general loading state
     setTimeout(() => {
@@ -120,22 +117,6 @@ export class SummaryAreaDemo implements OnInit {
   public onEditClick = (): void => {
     alert('Edit clicked!');
   };
-
-  public goToIconsPage(): void {
-    this.router.navigate(['/icons']);
-  }
-
-  public goToPagerRoute(): void {
-    this.router.navigate(['/pager']);
-  }
-
-  public goToClarityRoute(): void {
-    this.router.navigate(['/clarity']);
-  }
-
-  public goToExternalApp(): void {
-    window.open('https://external-app.example.com', '_blank');
-  }
 
   public openProgressDetails() {
     this.showProgressDetails = true;

--- a/website/src/app/documentation/demos/full-page-layouts/sidebar-page-layout/sidebar-page-layout.demo.html
+++ b/website/src/app/documentation/demos/full-page-layouts/sidebar-page-layout/sidebar-page-layout.demo.html
@@ -50,8 +50,7 @@
     <clr-summary-item label="Role">
       <clr-summary-item-value
         icon="administrator"
-        [clickable]="true"
-        (clicked)="navigateInternally('settings')"
+        href="/full-page-layouts/sidebarpage-layout/(fullpage:settings)"
         tooltip="Navigate to settings"
       ></clr-summary-item-value>
       <clr-summary-item-value value="Admin"></clr-summary-item-value>
@@ -68,16 +67,14 @@
     <clr-summary-item label="Manager" [valueCopyable]="true">
       <clr-summary-item-value
         value="Jane Smith"
-        [clickable]="true"
-        (clicked)="navigateInternally('profile')"
+        href="/full-page-layouts/sidebarpage-layout/(fullpage:profile)"
         tooltip="Navigate to profile"
       ></clr-summary-item-value>
     </clr-summary-item>
     <clr-summary-item label="Tasks" [loading]="itemLoadingState">
       <clr-summary-item-value
         value="5 open Tasks"
-        [clickable]="true"
-        (clicked)="navigateInternally('tasks')"
+        href="/full-page-layouts/sidebarpage-layout/(fullpage:tasks)"
       ></clr-summary-item-value>
     </clr-summary-item>
     <clr-summary-item label="Quota">
@@ -91,8 +88,8 @@
     <clr-summary-item label="References">
       <clr-summary-item-value
         value="Porsche Informatik"
-        [clickable]="true"
-        (clicked)="openReferencesWebsite()"
+        href="https://www.porscheinformatik.com/"
+        target="_blank"
       ></clr-summary-item-value>
     </clr-summary-item>
   </clr-summary-area>

--- a/website/src/app/documentation/demos/full-page-layouts/sidebar-page-layout/sidebar-page-layout.demo.ts
+++ b/website/src/app/documentation/demos/full-page-layouts/sidebar-page-layout/sidebar-page-layout.demo.ts
@@ -78,14 +78,6 @@ export class SidebarPageLayoutDemo implements OnInit {
     }, 10000);
   }
 
-  navigateInternally(page: string) {
-    this.router.navigate(['/full-page-layouts/sidebarpage-layout', { outlets: { fullpage: page } }]);
-  }
-
-  openReferencesWebsite() {
-    window.open('https://www.porscheinformatik.com/', '_blank');
-  }
-
   sendEmail(email: string) {
     globalThis.location.href = `mailto:${email}`;
   }

--- a/website/src/app/documentation/demos/summary-area/summary-area.demo.html
+++ b/website/src/app/documentation/demos/summary-area/summary-area.demo.html
@@ -77,6 +77,18 @@
         <code class="clr-code">(clicked)</code> event.
       </p>
 
+      <h4 class="sub-section-title">External and Internal Links via href</h4>
+      <p class="section">
+        Use the <code class="clr-code">[href]</code> input to render the value as a native
+        <code class="clr-code">&lt;a&gt;</code> element. This enables browser-native link behaviour such as
+        right-clicking to open the link in a new tab, middle-click support, and URL previews in the status bar — none of
+        which are available when using <code class="clr-code">[clickable]</code> with a
+        <code class="clr-code">(clicked)</code> handler. Use the optional <code class="clr-code">[target]</code> input
+        to control where the link opens (e.g. <code class="clr-code">target="_blank"</code> for a new tab). Both
+        <code class="clr-code">[href]</code> and <code class="clr-code">[clickable]</code> can be combined when you need
+        both native navigation and a custom side-effect.
+      </p>
+
       <h4 class="sub-section-title">Copy to Clipboard</h4>
       <p class="section">
         Items can be configured with the input <code class="clr-code">[valueCopyable]</code> to show a copy button that
@@ -321,6 +333,33 @@
             <td class="left clr-hidden-xs-down">EventEmitter&lt;void&gt;</td>
             <td class="clr-hidden-xs-down">—</td>
             <td class="left">Emitted when a clickable value is clicked</td>
+          </tr>
+          <tr>
+            <td class="left">
+              <b>[href]</b>
+              <div class="clr-hidden-sm-up">Type: string</div>
+            </td>
+            <td class="left clr-hidden-xs-down">string</td>
+            <td class="clr-hidden-xs-down">undefined</td>
+            <td class="left">
+              When set, renders the value as a native <code class="clr-code">&lt;a&gt;</code> element with this URL.
+              Enables right-click "Open in new tab" and other browser-native link behaviours. Can be combined with
+              <code class="clr-code">[clickable]</code> to also emit the <code class="clr-code">(clicked)</code> event.
+            </td>
+          </tr>
+          <tr>
+            <td class="left">
+              <b>[target]</b>
+              <div class="clr-hidden-sm-up">Type: string</div>
+            </td>
+            <td class="left clr-hidden-xs-down">string</td>
+            <td class="clr-hidden-xs-down">undefined</td>
+            <td class="left">
+              Sets the <code class="clr-code">target</code> attribute on the rendered
+              <code class="clr-code">&lt;a&gt;</code> element. Only has effect when
+              <code class="clr-code">[href]</code> is also provided. Use <code class="clr-code">"_blank"</code> to open
+              in a new tab.
+            </td>
           </tr>
         </tbody>
       </table>
@@ -801,7 +840,58 @@
 
       <clr-code-snippet [clrCode]="clickableExample"></clr-code-snippet>
 
-      <h4 class="sub-section-title">Multiple Values</h4>
+      <h4 class="sub-section-title">External and Internal Links via href</h4>
+      <p class="section">
+        Using <code class="clr-code">[href]</code> renders a native anchor element, enabling right-click "Open in new
+        tab", middle-click, and status-bar URL preview — unlike the <code class="clr-code">[clickable]</code> approach
+        which uses a <code class="clr-code">&lt;span&gt;</code>. Combine with
+        <code class="clr-code">target="_blank"</code> for external links.
+      </p>
+      <br />
+
+      <!-- External link — opens in a new tab, supports right-click "Open in new tab" -->
+      <clr-summary-area [rows]="3">
+        <clr-summary-item label="Documentation">
+          <clr-summary-item-value
+            value="Clarity Design"
+            href="https://clarity.design"
+            target="_blank"
+            tooltip="Opens Clarity Design in a new tab"
+          ></clr-summary-item-value>
+        </clr-summary-item>
+        <clr-summary-item label="Internal Page">
+          <clr-summary-item-value
+            value="Go to Page layouts"
+            href="/documentation/latest/page-layouts"
+          ></clr-summary-item-value>
+        </clr-summary-item>
+        <!-- Icons also support href — wraps cds-icon in a native <a> element -->
+        <clr-summary-item label="Icon Link">
+          <clr-summary-item-value
+            icon="pop-out"
+            href="https://clarity.design"
+            target="_blank"
+            tooltip="Open Clarity Design"
+          ></clr-summary-item-value>
+          <clr-summary-item-value
+            value="Clarity Design"
+            href="https://clarity.design"
+            target="_blank"
+          ></clr-summary-item-value>
+        </clr-summary-item>
+        <!-- href and clickable can be combined: navigates via href AND emits (clicked) -->
+        <clr-summary-item label="Combined">
+          <clr-summary-item-value
+            value="Open & Track"
+            href="https://clarity.design"
+            target="_blank"
+            [clickable]="true"
+            (clicked)="onLinkClicked()"
+          ></clr-summary-item-value>
+        </clr-summary-item>
+      </clr-summary-area>
+
+      <clr-code-snippet [clrCode]="hrefExample"></clr-code-snippet>
       <p class="section">A Summary Item can contain multiple text values, displayed in sequence.</p>
       <br />
 

--- a/website/src/app/documentation/demos/summary-area/summary-area.demo.ts
+++ b/website/src/app/documentation/demos/summary-area/summary-area.demo.ts
@@ -6,9 +6,17 @@
 
 import { ClarityDocComponent } from '../clarity-doc';
 import { Component, signal } from '@angular/core';
-import { ClarityIcons, checkCircleIcon, flagIcon, folderIcon, userIcon, usersIcon } from '@clr/angular/icon';
+import {
+  ClarityIcons,
+  checkCircleIcon,
+  flagIcon,
+  folderIcon,
+  userIcon,
+  usersIcon,
+  popOutIcon,
+} from '@clr/angular/icon';
 
-ClarityIcons.addIcons(userIcon, usersIcon, flagIcon, folderIcon, checkCircleIcon);
+ClarityIcons.addIcons(userIcon, usersIcon, flagIcon, folderIcon, checkCircleIcon, popOutIcon);
 
 const BASIC_EXAMPLE = `<clr-summary-area [rows]="3">
     <clr-summary-item label="Customer Name">
@@ -58,7 +66,7 @@ const CLICKABLE_EXAMPLE = `<clr-summary-area [rows]="1">
         (clicked)="handleValueClick()"
       ></clr-summary-item-value>
     </clr-summary-item>
-    <clr-summary-item label="External Link">
+    <clr-summary-item label="External Link (via clicked)">
       <clr-summary-item-value
         value="Open Documentation"
         [clickable]="true"
@@ -67,6 +75,48 @@ const CLICKABLE_EXAMPLE = `<clr-summary-area [rows]="1">
       ></clr-summary-item-value>
     </clr-summary-item>
   </clr-summary-area>`;
+
+const HREF_EXAMPLE = `<!-- External link — opens in a new tab, supports right-click "Open in new tab" -->
+<clr-summary-area [rows]="3">
+  <clr-summary-item label="Documentation">
+    <clr-summary-item-value
+      value="Clarity Design"
+      href="https://clarity.design"
+      target="_blank"
+      tooltip="Opens Clarity Design in a new tab"
+    ></clr-summary-item-value>
+  </clr-summary-item>
+  <clr-summary-item label="Internal Page">
+    <clr-summary-item-value
+      value="Go to Page layouts"
+      href="/documentation/latest/page-layouts"
+    ></clr-summary-item-value>
+  </clr-summary-item>
+  <!-- Icons also support href — wraps cds-icon in a native <a> element -->
+  <clr-summary-item label="Icon Link">
+    <clr-summary-item-value
+      icon="pop-out"
+      href="https://clarity.design"
+      target="_blank"
+      tooltip="Open Clarity Design"
+    ></clr-summary-item-value>
+    <clr-summary-item-value
+      value="Clarity Design"
+      href="https://clarity.design"
+      target="_blank"
+    ></clr-summary-item-value>
+  </clr-summary-item>
+  <!-- href and clickable can be combined: navigates via href AND emits (clicked) -->
+  <clr-summary-item label="Combined">
+    <clr-summary-item-value
+      value="Open & Track"
+      href="https://clarity.design"
+      target="_blank"
+      [clickable]="true"
+      (clicked)="onLinkClicked()"
+    ></clr-summary-item-value>
+  </clr-summary-item>
+</clr-summary-area>`;
 
 const MULTIPLE_VALUES_EXAMPLE = `<clr-summary-area [rows]="1">
     <clr-summary-item label="Tags" [valueCopyable]="true">
@@ -292,6 +342,7 @@ export class SummaryAreaDemo extends ClarityDocComponent {
   basicExample = BASIC_EXAMPLE;
   iconExample = ICON_EXAMPLE;
   clickableExample = CLICKABLE_EXAMPLE;
+  hrefExample = HREF_EXAMPLE;
   multipleValuesExample = MULTIPLE_VALUES_EXAMPLE;
   tooltipExample = TOOLTIP_EXAMPLE;
   emptyValueExample = EMPTY_VALUE_EXAMPLE;
@@ -319,6 +370,10 @@ export class SummaryAreaDemo extends ClarityDocComponent {
 
   openExternalLink(): void {
     window.open('https://clarity.design', '_blank');
+  }
+
+  onLinkClicked(): void {
+    console.log('Link clicked event emitted alongside href navigation');
   }
 
   viewCustomer(): void {


### PR DESCRIPTION
Extend implementation for ClrSummaryItemValue which represents a value item in ClrSummaryArea:
- Add input properties *href* and *target* to ClrSummaryItemValue  component
- If input *href* (and optionally also *target*) property is provided, wrap summary item value as a native \<a\> element
- This enables browser-native link behaviour such as right-clicking to open the link in a new tab, middle-click support, and URL previews in the status bar
- Use the optional *target* input to control where the link opens (e.g. target="_blank" for a new tab).