### PR TITLE
Collapse/Expand: Missing "Title"

### DIFF
--- a/src/clr-addons/collapse-expand-section/collapse-expand-section.html
+++ b/src/clr-addons/collapse-expand-section/collapse-expand-section.html
@@ -2,23 +2,14 @@
   <div class="ces-title" [class.disabled-header-styles]="disableHeaderStyles">
     @if (!disableHeaderStyles) {
     <h2>
-      <ng-container *ngTemplateOutlet="title"></ng-container>
+      <ng-content select="[clr-ces-title]"></ng-content>
+      <ng-container *ngTemplateOutlet="caretBtn"></ng-container>
     </h2>
     } @else {
     <ng-content select="[clr-ces-title]"></ng-content>
-    <button type="button" (click)="onCollapseExpand()" class="btn btn-icon btn-link ces-caret-btn">
-      <cds-icon
-        shape="angle"
-        direction="up"
-        size="28"
-        class="ces-caret-icon"
-        [@rotateIcon]="isCollapsed"
-        [@.disabled]="disableAnimation"
-      ></cds-icon>
-    </button>
+    <ng-container *ngTemplateOutlet="caretBtn"></ng-container>
     }
-    <ng-template #title>
-      <ng-content select="[clr-ces-title]"></ng-content>
+    <ng-template #caretBtn>
       <button type="button" (click)="onCollapseExpand()" class="btn btn-icon btn-link ces-caret-btn">
         <cds-icon
           shape="angle"
@@ -34,14 +25,11 @@
   <div class="ces-subtitle">
     @if (!disableHeaderStyles) {
     <h4>
-      <ng-container *ngTemplateOutlet="subtitle"></ng-container>
+      <ng-content select="[clr-ces-subtitle]"></ng-content>
     </h4>
     } @else {
     <ng-content select="[clr-ces-subtitle]"></ng-content>
     }
-    <ng-template #subtitle>
-      <ng-content select="[clr-ces-subtitle]"></ng-content>
-    </ng-template>
   </div>
   } @if (!isCollapsed) {
   <div [@collapseExpandAnimation]="isCollapsed" [@.disabled]="disableAnimation">

--- a/src/clr-addons/collapse-expand-section/collapse-expand-section.spec.ts
+++ b/src/clr-addons/collapse-expand-section/collapse-expand-section.spec.ts
@@ -4,6 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
@@ -11,13 +12,25 @@ import { ClarityModule } from '@clr/angular';
 import { ClrCollapseExpandSection } from './collapse-expand-section';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
+@Component({
+  template: `
+    <clr-collapse-expand-section [clrIsCollapsed]="false">
+      <ng-container clr-ces-title>Test Title</ng-container>
+      <ng-container clr-ces-subtitle>Test Subtitle</ng-container>
+      <ng-container clr-ces-content>Test Content</ng-container>
+    </clr-collapse-expand-section>
+  `,
+  standalone: false,
+})
+class CollapseExpandSectionHostComponent {}
+
 describe('CollapseExpandSectionComponent', () => {
   let component: ClrCollapseExpandSection;
   let fixture: ComponentFixture<ClrCollapseExpandSection>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ClrCollapseExpandSection],
+      declarations: [ClrCollapseExpandSection, CollapseExpandSectionHostComponent],
       imports: [ClarityModule, FormsModule, BrowserAnimationsModule],
     }).compileComponents();
   }));
@@ -50,5 +63,16 @@ describe('CollapseExpandSectionComponent', () => {
     spyOn(component.collapsed, 'emit');
     component.onCollapseExpand();
     expect(component.collapsed.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should project title, subtitle and content', () => {
+    const hostFixture = TestBed.createComponent(CollapseExpandSectionHostComponent);
+    hostFixture.detectChanges();
+
+    const textContent = hostFixture.nativeElement.textContent;
+
+    expect(textContent).toContain('Test Title');
+    expect(textContent).toContain('Test Subtitle');
+    expect(textContent).toContain('Test Content');
   });
 });


### PR DESCRIPTION
…arity addons

- The missing title was caused by projecting [clr-ces-title] through ng-template + *ngTemplateOutlet — that pattern breaks under Angular 21’s control flow. -- Title and subtitle are now projected directly in each @if branch -- Only the caret button stays in a shared #caretBtn template (no ng-content inside it)

- A unit test was added to assert title, subtitle, and content projection.