### PR TITLE
Fix collapse expand section clrDisableHeaderStyles

### DIFF
--- a/src/clr-addons/collapse-expand-section/collapse-expand-section.html
+++ b/src/clr-addons/collapse-expand-section/collapse-expand-section.html
@@ -11,7 +11,7 @@
         role="button"
         [attr.aria-expanded]="!isCollapsed"
       >
-        <ng-content select="[clr-ces-title]"></ng-content>
+        <ng-container *ngTemplateOutlet="titleContent"></ng-container>
       </span>
       <ng-container *ngTemplateOutlet="caretBtn"></ng-container>
     </h2>
@@ -25,10 +25,13 @@
       role="button"
       [attr.aria-expanded]="!isCollapsed"
     >
-      <ng-content select="[clr-ces-title]"></ng-content>
+      <ng-container *ngTemplateOutlet="titleContent"></ng-container>
     </span>
     <ng-container *ngTemplateOutlet="caretBtn"></ng-container>
     }
+    <ng-template #titleContent>
+      <ng-content select="[clr-ces-title]"></ng-content>
+    </ng-template>
     <ng-template #caretBtn>
       <button type="button" (click)="onCollapseExpand()" class="btn btn-icon btn-link ces-caret-btn">
         <cds-icon
@@ -45,11 +48,14 @@
   <div class="ces-subtitle">
     @if (!disableHeaderStyles) {
     <h4>
-      <ng-content select="[clr-ces-subtitle]"></ng-content>
+      <ng-container *ngTemplateOutlet="subtitleContent"></ng-container>
     </h4>
     } @else {
-    <ng-content select="[clr-ces-subtitle]"></ng-content>
+    <ng-container *ngTemplateOutlet="subtitleContent"></ng-container>
     }
+    <ng-template #subtitleContent>
+      <ng-content select="[clr-ces-subtitle]"></ng-content>
+    </ng-template>
   </div>
   } @if (!isCollapsed) {
   <div [@collapseExpandAnimation]="isCollapsed" [@.disabled]="disableAnimation">

--- a/src/clr-addons/collapse-expand-section/collapse-expand-section.spec.ts
+++ b/src/clr-addons/collapse-expand-section/collapse-expand-section.spec.ts
@@ -24,13 +24,29 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 })
 class CollapseExpandSectionHostComponent {}
 
+@Component({
+  template: `
+    <clr-collapse-expand-section [clrIsCollapsed]="false" [clrDisableHeaderStyles]="true">
+      <ng-container clr-ces-title>Test Title</ng-container>
+      <ng-container clr-ces-subtitle>Test Subtitle</ng-container>
+      <ng-container clr-ces-content>Test Content</ng-container>
+    </clr-collapse-expand-section>
+  `,
+  standalone: false,
+})
+class CollapseExpandSectionDisabledHeaderStylesHostComponent {}
+
 describe('CollapseExpandSectionComponent', () => {
   let component: ClrCollapseExpandSection;
   let fixture: ComponentFixture<ClrCollapseExpandSection>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ClrCollapseExpandSection, CollapseExpandSectionHostComponent],
+      declarations: [
+        ClrCollapseExpandSection,
+        CollapseExpandSectionHostComponent,
+        CollapseExpandSectionDisabledHeaderStylesHostComponent,
+      ],
       imports: [ClarityModule, FormsModule, BrowserAnimationsModule],
     }).compileComponents();
   }));
@@ -67,6 +83,17 @@ describe('CollapseExpandSectionComponent', () => {
 
   it('should project title, subtitle and content', () => {
     const hostFixture = TestBed.createComponent(CollapseExpandSectionHostComponent);
+    hostFixture.detectChanges();
+
+    const textContent = hostFixture.nativeElement.textContent;
+
+    expect(textContent).toContain('Test Title');
+    expect(textContent).toContain('Test Subtitle');
+    expect(textContent).toContain('Test Content');
+  });
+
+  it('should project title and subtitle when clrDisableHeaderStyles is true', () => {
+    const hostFixture = TestBed.createComponent(CollapseExpandSectionDisabledHeaderStylesHostComponent);
     hostFixture.detectChanges();
 
     const textContent = hostFixture.nativeElement.textContent;

--- a/src/dev/src/app/collapse-expand-section/collapse-expand-section.demo.html
+++ b/src/dev/src/app/collapse-expand-section/collapse-expand-section.demo.html
@@ -54,3 +54,20 @@
     >
   </ng-container>
 </clr-collapse-expand-section>
+
+<br />
+
+<clr-collapse-expand-section [clrDisableHeaderStyles]="true">
+  <ng-container clr-ces-title>Title with disabled styles</ng-container>
+  <ng-container clr-ces-subtitle>Subtitle with disabled styles</ng-container>
+  <ng-container clr-ces-content>
+    <span
+      >Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+      dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita
+      kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur
+      sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+      voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
+      sanctus est Lorem ipsum dolor sit amet.</span
+    >
+  </ng-container>
+</clr-collapse-expand-section>


### PR DESCRIPTION
Currently no title or subtitle is shown when clrDisableHeaderStyles=true

- Broken with the control flow migration
- This did not work anymore as only the first "select" is filled by Angular