### PR TITLE
fix(icon): remove stale transform blocking clr-icon direction rotation

### DIFF
--- a/src/clr-addons/components.clr-addons.scss
+++ b/src/clr-addons/components.clr-addons.scss
@@ -442,10 +442,6 @@ clr-date-container .clr-control-container {
   white-space: nowrap;
 }
 
-.btn clr-icon {
-  transform: translate3d(0, -0.1rem, 0);
-}
-
 .clr-treenode-link:hover:visited {
   color: inherit;
 }


### PR DESCRIPTION
`<clr-icon>`/`<cds-icon>` elements with a `direction` attribute (e.g. `direction="right"`)
don't visually rotate when rendered inside a `.btn`.

Removed `.btn clr-icon { transform: translate3d(0, -0.1rem, 0); }` from
`components.clr-addons.scss`. See root cause below:

The icon's rotation is applied directly to its host tag (`<clr-icon>`), not to something safely tucked inside its shadow DOM. So this rule, which also sets transform on that same tag, overwrites the rotation instead of combining with it.

Example before/after:

<img width="1600" height="642" alt="ss1" src="https://github.com/user-attachments/assets/67bafbbd-9791-42fd-820e-26dc37cee0b0" />

<img width="1600" height="595" alt="ss2" src="https://github.com/user-attachments/assets/14a8d247-d9eb-4860-9786-79ef51837e46" />
