### PR TITLE
Add badge to card title of view-edit-section

### DIFF
--- a/src/clr-addons/view-edit-section/view-edit-section.html
+++ b/src/clr-addons/view-edit-section/view-edit-section.html
@@ -1,6 +1,13 @@
 <div class="card view-edit-section" (keyup.escape)="onCancel()">
   <div class="card-block">
     <div class="card-title" [attr.cds-text]="_titleTextStyle + ' ' + _titleTextFontWeight">
+      <ng-template #titleContainer>
+        {{ _title }} @if (_showBadge) { @if (_badgeContent) {
+        <span class="ves-badge" [ngClass]="_badgeClass">{{ _badgeContent }}</span>
+        }
+        <ng-content select="[badge]"></ng-content>
+        }
+      </ng-template>
       @if (_isCollapsible && !editMode) {
       <span
         class="ces-title-trigger"
@@ -11,12 +18,14 @@
         role="button"
         [attr.aria-expanded]="!_isCollapsed"
       >
-        {{ _title }}
+        <ng-template [ngTemplateOutlet]="titleContainer"></ng-template>
       </span>
       <button type="button" (click)="onCollapseExpand()" class="btn btn-icon btn-link ces-caret-btn">
         <cds-icon shape="angle" size="20" class="ces-caret-icon" [@rotateIcon]="_isCollapsed"></cds-icon>
       </button>
-      } @else { {{ _title }} }
+      } @else {
+      <ng-template [ngTemplateOutlet]="titleContainer"></ng-template>
+      }
       <div class="ves-actions">
         @if (_editable && !editMode && actionBlock.children.length == 0) {
         <button type="button" (click)="onEdit()" class="btn btn-icon btn-link ves-action">

--- a/src/clr-addons/view-edit-section/view-edit-section.scss
+++ b/src/clr-addons/view-edit-section/view-edit-section.scss
@@ -41,6 +41,11 @@
     cursor: pointer;
   }
 
+  .ves-badge {
+    margin-left: 0.5rem;
+    vertical-align: middle;
+  }
+
   .btn.btn-link.ces-caret-btn {
     color: var(--cds-alias-typography-color-300);
 

--- a/src/clr-addons/view-edit-section/view-edit-section.spec.ts
+++ b/src/clr-addons/view-edit-section/view-edit-section.spec.ts
@@ -65,13 +65,50 @@ class EditIconComponent {
 })
 class NotEditableComponent {}
 
+@Component({
+  template: `
+    <clr-view-edit-section
+      clrTitle="Badge title"
+      [clrShowBadge]="showBadge"
+      [clrBadgeContent]="badgeContent"
+      [clrBadgeClass]="badgeClass"
+    >
+    </clr-view-edit-section>
+  `,
+  standalone: false,
+})
+class StringBadgeComponent {
+  showBadge = true;
+  badgeContent = 'Badge content';
+  badgeClass: string | string[] = 'label label-primary';
+}
+
+@Component({
+  template: `
+    <clr-view-edit-section clrTitle="Badge title" [clrShowBadge]="showBadge">
+      <span badge class="custom-projected-badge">Projected</span>
+    </clr-view-edit-section>
+  `,
+  standalone: false,
+})
+class ProjectedBadgeComponent {
+  showBadge = true;
+}
+
 describe('ViewEditSectionComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let component: ClrViewEditSection;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [TestComponent, EditIconComponent, EditModeComponent, NotEditableComponent],
+      declarations: [
+        TestComponent,
+        EditIconComponent,
+        EditModeComponent,
+        NotEditableComponent,
+        StringBadgeComponent,
+        ProjectedBadgeComponent,
+      ],
       imports: [ClarityModule, ClrViewEditSectionModule, BrowserAnimationsModule],
     }).compileComponents();
   }));
@@ -211,5 +248,56 @@ describe('ViewEditSectionComponent', () => {
     fixture.nativeElement.querySelector('.ces-title-trigger').click();
 
     expect(component._isCollapsed).toBeTrue();
+  });
+
+  it('shows the string badge with default class', () => {
+    const badgeFixture: ComponentFixture<StringBadgeComponent> = TestBed.createComponent(StringBadgeComponent);
+    badgeFixture.detectChanges();
+
+    const badge = badgeFixture.nativeElement.querySelector('.ves-badge');
+    expect(badge).not.toBeNull();
+    expect(badge.textContent).toContain('Badge content');
+    expect(badge.classList).toContain('label');
+    expect(badge.classList).toContain('label-primary');
+    badgeFixture.destroy();
+  });
+
+  it('applies a custom badge class', () => {
+    const badgeFixture: ComponentFixture<StringBadgeComponent> = TestBed.createComponent(StringBadgeComponent);
+    badgeFixture.componentInstance.badgeClass = 'label label-warning';
+    badgeFixture.detectChanges();
+
+    const badge = badgeFixture.nativeElement.querySelector('.ves-badge');
+    expect(badge.classList).toContain('label-warning');
+    expect(badge.classList).not.toContain('label-primary');
+    badgeFixture.destroy();
+  });
+
+  it('does not render the string badge when clrShowBadge is false', () => {
+    const badgeFixture: ComponentFixture<StringBadgeComponent> = TestBed.createComponent(StringBadgeComponent);
+    badgeFixture.componentInstance.showBadge = false;
+    badgeFixture.detectChanges();
+
+    expect(badgeFixture.nativeElement.querySelector('.ves-badge')).toBeNull();
+    badgeFixture.destroy();
+  });
+
+  it('renders a projected badge when clrShowBadge is true', () => {
+    const badgeFixture: ComponentFixture<ProjectedBadgeComponent> = TestBed.createComponent(ProjectedBadgeComponent);
+    badgeFixture.detectChanges();
+
+    const projected = badgeFixture.nativeElement.querySelector('[badge].custom-projected-badge');
+    expect(projected).not.toBeNull();
+    expect(projected.textContent).toContain('Projected');
+    badgeFixture.destroy();
+  });
+
+  it('does not render a projected badge when clrShowBadge is false', () => {
+    const badgeFixture: ComponentFixture<ProjectedBadgeComponent> = TestBed.createComponent(ProjectedBadgeComponent);
+    badgeFixture.componentInstance.showBadge = false;
+    badgeFixture.detectChanges();
+
+    expect(badgeFixture.nativeElement.querySelector('[badge].custom-projected-badge')).toBeNull();
+    badgeFixture.destroy();
   });
 });

--- a/src/clr-addons/view-edit-section/view-edit-section.ts
+++ b/src/clr-addons/view-edit-section/view-edit-section.ts
@@ -57,6 +57,9 @@ export class ClrViewEditSection implements AfterViewInit {
   @Input('clrIsCollapsed') _isCollapsed = false;
   @Input('clrTitleTextStyle') _titleTextStyle: ClrViewEditSectionTitleTextStyle = 'subsection';
   @Input('clrTitleTextFontWeight') _titleTextFontWeight: ClrViewEditSectionTitleTextFontWeight = 'medium';
+  @Input('clrShowBadge') _showBadge = false;
+  @Input('clrBadgeContent') _badgeContent: string;
+  @Input('clrBadgeClass') _badgeClass: string | string[] = 'label label-primary';
 
   @Input('clrViewRef') viewRef: TemplateRef<any>;
   @Input('clrEditRef') editRef: TemplateRef<any>;

--- a/src/dev/src/app/view-edit-section/view-edit-section.demo.html
+++ b/src/dev/src/app/view-edit-section/view-edit-section.demo.html
@@ -206,5 +206,78 @@
         </ng-template>
       </clr-view-edit-section>
     </div>
+
+    <div class="clr-col-12">
+      <clr-view-edit-section
+        clrTitle="With badge"
+        [clrEditable]="false"
+        [clrViewRef]="viewBlock5"
+        [clrShowBadge]="true"
+        clrBadgeContent="Badge content"
+      >
+        <ng-template #viewBlock5>
+          <form clrForm clrLayout="horizontal">
+            <div class="clr-form-control clr-row">
+              <label class="clr-col-md-2 clr-control-label">Hobby</label>
+              <span class="text-truncate clr-col-md-10">Computer</span>
+            </div>
+            <div class="clr-form-control clr-row">
+              <label class="clr-col-md-2 clr-control-label">Driving licence number</label>
+              <span class="text-truncate clr-col-md-10">12345</span>
+            </div>
+          </form>
+        </ng-template>
+      </clr-view-edit-section>
+    </div>
+
+    <div class="clr-col-12">
+      <clr-view-edit-section
+        clrTitle="With custom-styled badge"
+        [clrEditable]="false"
+        [clrViewRef]="viewBlock5"
+        [clrShowBadge]="true"
+        clrBadgeContent="Warning"
+        clrBadgeClass="label label-warning"
+      >
+        <ng-template #viewBlock5>
+          <form clrForm clrLayout="horizontal">
+            <div class="clr-form-control clr-row">
+              <label class="clr-col-md-2 clr-control-label">Hobby</label>
+              <span class="text-truncate clr-col-md-10">Computer</span>
+            </div>
+            <div class="clr-form-control clr-row">
+              <label class="clr-col-md-2 clr-control-label">Driving licence number</label>
+              <span class="text-truncate clr-col-md-10">12345</span>
+            </div>
+          </form>
+        </ng-template>
+      </clr-view-edit-section>
+    </div>
+
+    <div class="clr-col-12">
+      <clr-view-edit-section
+        clrTitle="With projected badge"
+        [clrEditable]="false"
+        [clrShowBadge]="true"
+        [clrViewRef]="viewBlock5"
+      >
+        <span badge class="label label-success">
+          <cds-icon shape="check"></cds-icon>
+          Verified
+        </span>
+        <ng-template #viewBlock5>
+          <form clrForm clrLayout="horizontal">
+            <div class="clr-form-control clr-row">
+              <label class="clr-col-md-2 clr-control-label">Hobby</label>
+              <span class="text-truncate clr-col-md-10">Computer</span>
+            </div>
+            <div class="clr-form-control clr-row">
+              <label class="clr-col-md-2 clr-control-label">Driving licence number</label>
+              <span class="text-truncate clr-col-md-10">12345</span>
+            </div>
+          </form>
+        </ng-template>
+      </clr-view-edit-section>
+    </div>
   </div>
 </div>

--- a/website/src/app/documentation/demos/view-edit-section/view-edit-section.demo.html
+++ b/website/src/app/documentation/demos/view-edit-section/view-edit-section.demo.html
@@ -207,6 +207,55 @@
           </tr>
           <tr>
             <td class="left">
+              <b>[clrShowBadge]</b>
+              <div class="clr-hidden-sm-up">Type: boolean</div>
+              <div class="clr-hidden-sm-up">Default: false</div>
+            </td>
+            <td class="left clr-hidden-xs-down">true, false</td>
+            <td class="clr-hidden-xs-down">false</td>
+            <td class="left">
+              Shows the built-in string badge next to the title (used together with
+              <code class="clr-code">clrBadgeContent</code>)
+            </td>
+          </tr>
+          <tr>
+            <td class="left">
+              <b>[clrBadgeContent]</b>
+              <div class="clr-hidden-sm-up">Type: String</div>
+              <div class="clr-hidden-sm-up">Default: undefined</div>
+            </td>
+            <td class="left clr-hidden-xs-down">any string</td>
+            <td class="clr-hidden-xs-down">undefined</td>
+            <td class="left">Text content of the built-in string badge</td>
+          </tr>
+          <tr>
+            <td class="left">
+              <b>[clrBadgeClass]</b>
+              <div class="clr-hidden-sm-up">Type: string | string[]</div>
+              <div class="clr-hidden-sm-up">Default: "label label-primary"</div>
+            </td>
+            <td class="left clr-hidden-xs-down">any CSS class(es)</td>
+            <td class="clr-hidden-xs-down">"label label-primary"</td>
+            <td class="left">
+              CSS class(es) applied to the built-in string badge, allowing its style to be customized (e.g.
+              <code class="clr-code">label label-warning</code>)
+            </td>
+          </tr>
+          <tr>
+            <td class="left">
+              <b>[clrBadgeRef]</b>
+              <div class="clr-hidden-sm-up">Type: TemplateRef</div>
+              <div class="clr-hidden-sm-up">Default: undefined</div>
+            </td>
+            <td class="left clr-hidden-xs-down">any template reference</td>
+            <td class="clr-hidden-xs-down">undefined</td>
+            <td class="left">
+              Template rendered as the badge. Takes precedence over <code class="clr-code">clrBadgeContent</code> and
+              allows fully customized badge markup
+            </td>
+          </tr>
+          <tr>
+            <td class="left">
               <b>(clrSectionSubmitted)</b>
               <div class="clr-hidden-sm-up">Type: EventEmitter</div>
               <div class="clr-hidden-sm-up"></div>
@@ -228,6 +277,12 @@
         </tbody>
       </table>
       <p>To define custom actions simply put the attribute <code class="clr-code">action-block</code> to an element.</p>
+      <p>
+        To show a fully customized badge next to the title, project any element with the attribute
+        <code class="clr-code">badge</code>. For simple text badges the <code class="clr-code">clrShowBadge</code> /
+        <code class="clr-code">clrBadgeContent</code> inputs can be used, and their style can be adjusted via
+        <code class="clr-code">clrBadgeClass</code>.
+      </p>
     </div>
 
     <div id="code-examples">


### PR DESCRIPTION
This PR added the option to add a badge next to title in `clr-view-edit-section`

The badge could be added in multiple ways, provided that `clrShowBadge` is set to true

- via `clrBadgeRef`, which allows for projection of content via ng-template
<img width="466" height="187" alt="image" src="https://github.com/user-attachments/assets/59b6803f-3608-4f6a-8e95-ecb3c3b30320" />

- via `clrBadgeContent` and `clrBadgeClass`. If `clrBadgeClass` is not specified, the styles of label and label-primary will be used
<img width="1547" height="352" alt="image" src="https://github.com/user-attachments/assets/779b097f-8381-411e-84f0-58c3a257bf19" />

