### PR TITLE
Fix view edit section clrTitleTextStyle

### DIFF
--- a/src/clr-addons/view-edit-section/view-edit-section.html
+++ b/src/clr-addons/view-edit-section/view-edit-section.html
@@ -1,28 +1,32 @@
 <div class="card view-edit-section" (keyup.escape)="onCancel()">
   <div class="card-block">
-    <div class="card-title" [attr.cds-text]="_titleTextStyle + ' ' + _titleTextFontWeight">
+    <div class="card-title">
       <ng-template #titleContainer>
-        {{ _title }} @if (_showBadge) { @if (_badgeContent) {
-        <span class="ves-badge" [ngClass]="_badgeClass">{{ _badgeContent }}</span>
-        }
-        <ng-content select="[badge]"></ng-content>
-        }
+        <span class="ves-title-text" [attr.cds-text]="_titleTextStyle + ' ' + _titleTextFontWeight">
+          {{ _title }} @if (_showBadge) { @if (_badgeContent) {
+          <span class="ves-badge" [ngClass]="_badgeClass">{{ _badgeContent }}</span>
+          }
+          <ng-content select="[badge]"></ng-content>
+          }
+        </span>
       </ng-template>
       @if (_isCollapsible && !editMode) {
-      <span
-        class="ces-title-trigger"
-        (click)="onCollapseExpand()"
-        (keydown.enter)="onCollapseExpand()"
-        (keydown.space)="onCollapseExpand(); $event.preventDefault()"
-        tabindex="0"
-        role="button"
-        [attr.aria-expanded]="!_isCollapsed"
-      >
-        <ng-template [ngTemplateOutlet]="titleContainer"></ng-template>
+      <span class="ces-title-row">
+        <span
+          class="ces-title-trigger"
+          (click)="onCollapseExpand()"
+          (keydown.enter)="onCollapseExpand()"
+          (keydown.space)="onCollapseExpand(); $event.preventDefault()"
+          tabindex="0"
+          role="button"
+          [attr.aria-expanded]="!_isCollapsed"
+        >
+          <ng-template [ngTemplateOutlet]="titleContainer"></ng-template>
+        </span>
+        <button type="button" (click)="onCollapseExpand()" class="btn btn-icon btn-link ces-caret-btn">
+          <cds-icon shape="angle" size="20" class="ces-caret-icon" [@rotateIcon]="_isCollapsed"></cds-icon>
+        </button>
       </span>
-      <button type="button" (click)="onCollapseExpand()" class="btn btn-icon btn-link ces-caret-btn">
-        <cds-icon shape="angle" size="20" class="ces-caret-icon" [@rotateIcon]="_isCollapsed"></cds-icon>
-      </button>
       } @else {
       <ng-template [ngTemplateOutlet]="titleContainer"></ng-template>
       }

--- a/src/clr-addons/view-edit-section/view-edit-section.scss
+++ b/src/clr-addons/view-edit-section/view-edit-section.scss
@@ -14,6 +14,16 @@
       margin-bottom: 0;
     }
 
+    .ves-title-text {
+      display: inline-block;
+    }
+
+    .ces-title-row {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+    }
+
     .card-text {
       padding-right: 10px;
     }

--- a/src/dev/src/app/view-edit-section/view-edit-section.demo.html
+++ b/src/dev/src/app/view-edit-section/view-edit-section.demo.html
@@ -279,5 +279,28 @@
         </ng-template>
       </clr-view-edit-section>
     </div>
+
+    <div class="clr-col-12">
+      <clr-view-edit-section
+        clrTitle="With header style"
+        [clrEditable]="false"
+        [clrShowBadge]="true"
+        [clrViewRef]="viewBlock5"
+        [clrTitleTextStyle]="'headline'"
+      >
+        <ng-template #viewBlock5>
+          <form clrForm clrLayout="horizontal">
+            <div class="clr-form-control clr-row">
+              <label class="clr-col-md-2 clr-control-label">Hobby</label>
+              <span class="text-truncate clr-col-md-10">Computer</span>
+            </div>
+            <div class="clr-form-control clr-row">
+              <label class="clr-col-md-2 clr-control-label">Driving licence number</label>
+              <span class="text-truncate clr-col-md-10">12345</span>
+            </div>
+          </form>
+        </ng-template>
+      </clr-view-edit-section>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
After the Angular 21 upgrade custom header styling of view edit sections were not applied anymore. 

This PR fixes that
<img width="1990" height="259" alt="image" src="https://github.com/user-attachments/assets/297ea7e0-2969-4189-9a9a-8fb3f751c298" />

