### PR TITLE
Fix styling of control-warning directive

### DIFF
--- a/src/clr-addons/clr-control-warning/if-warning.directive.ts
+++ b/src/clr-addons/clr-control-warning/if-warning.directive.ts
@@ -6,7 +6,7 @@ import { ClrIcon } from '@clr/angular';
   standalone: false,
 })
 export class ClrIfWarning {
-  private hostElement: Element;
+  private helperElement: Element;
   private formContainer: Element;
   private iconRef: ComponentRef<ClrIcon>;
 
@@ -21,9 +21,16 @@ export class ClrIfWarning {
     if (clrIfWarning) {
       this.container.createEmbeddedView(this.template);
       setTimeout(() => {
-        this.hostElement = this.host.nativeElement?.previousElementSibling;
-        const wrapper = this.hostElement?.previousElementSibling;
-        this.formContainer = this.getFormContainer(wrapper);
+        // Angular inserts a structural directive's embedded view right
+        // before the anchor comment left behind by this directive, so the
+        // rendered `<clr-control-helper>` element is its previous sibling.
+        this.helperElement = this.host.nativeElement?.previousElementSibling;
+
+        if (!this.helperElement) {
+          return;
+        }
+
+        this.formContainer = this.helperElement.closest('.clr-control-container');
 
         if (!this.iconRef) {
           this.iconRef = this.container.createComponent(ClrIcon);
@@ -32,34 +39,39 @@ export class ClrIfWarning {
         }
         const iconEl = this.iconRef.location.nativeElement;
 
-        //Radio buttons have no wrapper
-        if (!wrapper) {
-          this.formContainer = this.getFormContainer(this.hostElement?.parentElement);
-          this.renderer.insertBefore(this.hostElement?.parentElement, iconEl, this.hostElement);
-        }
-        //if an error icon is already present, place the icon in the parent
-        if (wrapper?.classList?.contains('clr-validate-icon')) {
-          this.renderer.insertBefore(wrapper.parentElement, iconEl, wrapper?.nextSibling);
+        const parent = this.helperElement.parentElement;
+
+        // clr-checkbox-container / clr-radio-container already group their
+        // clr-control-helper inside a `.clr-subtext-wrapper` div, mirroring
+        // the layout Clarity uses for clr-control-error (icon + text in a
+        // single row). In that case we just need to place our icon in there.
+        if (parent?.classList?.contains('clr-subtext-wrapper')) {
+          this.renderer.insertBefore(parent, iconEl, this.helperElement);
         } else {
-          this.renderer.insertBefore(wrapper, iconEl, wrapper?.previousElementSibling);
+          // For other controls (input, textarea, select, date, combobox, ...)
+          // no such wrapper exists, so create one ourselves to replicate the
+          // same icon + text row layout used by clr-control-error.
+          const ownSubtextWrapper = this.renderer.createElement('div');
+          this.renderer.addClass(ownSubtextWrapper, 'clr-subtext-wrapper');
+          this.renderer.insertBefore(parent, ownSubtextWrapper, this.helperElement);
+          this.renderer.appendChild(ownSubtextWrapper, iconEl);
+          this.renderer.appendChild(ownSubtextWrapper, this.helperElement);
         }
+
         this.setControlStyles();
       });
     } else {
       this.resetControlStyles();
+
       this.iconRef?.destroy();
       this.iconRef = undefined;
       this.container.clear();
     }
   }
 
-  getFormContainer(element: Element) {
-    return element?.parentElement;
-  }
-
   resetControlStyles() {
-    if (this.hostElement) {
-      this.renderer.removeClass(this.hostElement, 'clr-warning');
+    if (this.helperElement) {
+      this.renderer.removeClass(this.helperElement, 'clr-warning');
     }
     if (this.formContainer) {
       this.renderer.removeClass(this.formContainer, 'clr-warning');
@@ -67,8 +79,8 @@ export class ClrIfWarning {
   }
 
   setControlStyles() {
-    if (this.hostElement) {
-      this.renderer.addClass(this.hostElement, 'clr-warning');
+    if (this.helperElement) {
+      this.renderer.addClass(this.helperElement, 'clr-warning');
     }
     if (this.formContainer) {
       this.renderer.addClass(this.formContainer, 'clr-warning');

--- a/src/clr-addons/components.clr-addons.scss
+++ b/src/clr-addons/components.clr-addons.scss
@@ -655,10 +655,13 @@ clr-control-helper.clr-warning {
 
 .clr-control-warning-icon {
   color: components.$clr-highlight-warning-800;
-  height: 1.2rem;
-  width: 1.2rem;
-  min-height: 1.2rem;
-  min-width: 1.2rem;
+  // Match the sizing Clarity uses for the clr-control-error icon
+  // (.clr-validate-icon), so warning and error rows line up visually.
+  height: var(--clr-forms-icon-size);
+  width: var(--clr-forms-icon-size);
+  min-height: var(--clr-forms-icon-size);
+  min-width: var(--clr-forms-icon-size);
+  flex-shrink: 0;
 }
 
 .clr-copy-to-clipboard-container:has(clr-copy-to-clipboard) {

--- a/src/dev/src/app/app.component.html
+++ b/src/dev/src/app/app.component.html
@@ -21,6 +21,9 @@
           <a class="nav-link" routerLink="/view-edit-section" routerLinkActive="active" clrMainNavGroupItem>
             ViewEdit Section
           </a>
+          <a class="nav-link" routerLink="/control-warning" routerLinkActive="active" clrMainNavGroupItem>
+            Control Warning
+          </a>
           <a class="nav-link" href="#" onClick="return false;" clrMainNavGroupItem>Submenu 3 3</a>
         </clr-main-nav-group>
         <clr-main-nav-group [clrTitle]="'Main Nav Group 2'" routerLinkActive="active">
@@ -50,9 +53,9 @@
         </button>
         <clr-dropdown-menu clrPosition="bottom-right" *clrIfOpen>
           @for (theme of themes; track theme) {
-          <button type="button" (click)="setTheme(theme)" clrDropdownItem>
-            {{ theme.name }}
-          </button>
+            <button type="button" (click)="setTheme(theme)" clrDropdownItem>
+              {{ theme.name }}
+            </button>
           }
         </clr-dropdown-menu>
       </clr-dropdown>

--- a/src/dev/src/app/app.routing.ts
+++ b/src/dev/src/app/app.routing.ts
@@ -48,6 +48,10 @@ export const APP_ROUTES: Routes = [
     loadChildren: () =>
       import('./view-edit-section/view-edit-section.demo.module').then(m => m.ViewEditSectionDemoModule),
   },
+  {
+    path: 'control-warning',
+    loadChildren: () => import('./control-warning/control-warning.demo.module').then(m => m.ControlWarningDemoModule),
+  },
   { path: 'clarity', loadChildren: () => import('./clarity/clarity.demo.module').then(m => m.ClarityDemoModule) },
   { path: 'pager', loadChildren: () => import('./pager/pager.demo.module').then(m => m.PagerDemoModule) },
   {

--- a/src/dev/src/app/control-warning/control-warning.demo.html
+++ b/src/dev/src/app/control-warning/control-warning.demo.html
@@ -1,0 +1,78 @@
+<!--
+~ Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+~ This software is released under MIT license.
+~ The full license information can be found in LICENSE in the root directory of this project.
+-->
+
+<h2>Control Warning</h2>
+
+<div class="clr-example">
+  <div>
+    <button (click)="showTextInputWarnings()" class="btn btn-primary">
+      {{ showingInputWarnings ? 'Hide' : 'Show' }} all warnings
+    </button>
+    <button (click)="toggleInputFormValidation()" class="btn btn-primary">
+      {{ isInputFormValidating ? 'Validate' : 'Reset' }} form
+    </button>
+  </div>
+  <form [formGroup]="inputForm" clrForm>
+    <clr-input-container class="clr-col-12">
+      <label class="clr-required-mark">Input label</label>
+      <input class="clr-col-5" clrInput formControlName="input" minlength="5" name="inputName" required type="text" />
+      <clr-control-error *clrIfError="'required'">Error message about being required</clr-control-error>
+      <clr-control-helper *clrIfWarning="showingInputWarnings" id="inputWarning">This is a warning </clr-control-helper>
+    </clr-input-container>
+
+    <clr-textarea-container class="clr-col-12">
+      <label class="clr-required-mark">Textarea label</label>
+      <textarea class="clr-col-7" clrTextarea formControlName="textArea" name="description" required></textarea>
+      <clr-control-error *clrIfError="'required'">Error message about being required</clr-control-error>
+      <clr-control-helper *clrIfWarning="showingInputWarnings">This is a warning</clr-control-helper>
+    </clr-textarea-container>
+
+    <clr-date-container class="clr-col-12">
+      <label class="clr-required-mark">Date label</label>
+      <input class="clr-col-5" clrDate formControlName="date" name="date" required type="text" />
+      <clr-control-helper *clrIfWarning="showingInputWarnings">This is a warning</clr-control-helper>
+      <clr-control-error *clrIfError="'required'">Error message about being required</clr-control-error>
+    </clr-date-container>
+
+    <clr-input-container class="clr-col-12">
+      <label class="clr-required-mark">Time label</label>
+      <input class="time-width" clrInput formControlName="time" name="time" required type="time" />
+      <clr-control-helper *clrIfWarning="showingInputWarnings">This is a warning</clr-control-helper>
+      <clr-control-error *clrIfError="'required'">Error message about being required</clr-control-error>
+    </clr-input-container>
+
+    <clr-select-container class="clr-col-12">
+      <label class="clr-required-mark">Select label</label>
+      <select class="clr-col-5" clrSelect formControlName="select" name="options" required>
+        <option value="one">One</option>
+        <option value="two">Two</option>
+        <option value="three">Three</option>
+      </select>
+      <clr-control-helper *clrIfWarning="showingInputWarnings">This is a warning</clr-control-helper>
+      <clr-control-error *clrIfError="'required'">Error message about being required</clr-control-error>
+    </clr-select-container>
+    <clr-combobox-container class="clr-col-12">
+      <label>Single Select Combobox</label>
+      <clr-combobox class="clr-col-5 custom-clrbox" formControlName="comboSingle" name="combobox" required>
+        <clr-options>
+          <clr-option *clrOptionItems="let option of values$ | async" [clrValue]="option">{{ option }}</clr-option>
+        </clr-options>
+      </clr-combobox>
+      <clr-control-error *clrIfError="'required'">Error message about being required</clr-control-error>
+      <clr-control-helper *clrIfWarning="showingInputWarnings">{{ comboBoxWarningString }}</clr-control-helper>
+    </clr-combobox-container>
+
+    <clr-checkbox-container class="clr-col-12">
+      <label>Checkbox label</label>
+      <clr-checkbox-wrapper>
+        <label class="clr-col-12">Option</label>
+        <input clrCheckbox formControlName="checkbox" name="checkboxName" required type="checkbox" />
+      </clr-checkbox-wrapper>
+      <clr-control-error *clrIfError="'required'">This is required</clr-control-error>
+      <clr-control-helper *clrIfWarning="showingInputWarnings">This is a warning</clr-control-helper>
+    </clr-checkbox-container>
+  </form>
+</div>

--- a/src/dev/src/app/control-warning/control-warning.demo.module.ts
+++ b/src/dev/src/app/control-warning/control-warning.demo.module.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+
+import { ClarityModule, ClrCommonFormsModule } from '@clr/angular';
+import { ClrAddonsModule } from '@porscheinformatik/clr-addons';
+
+import { ControlWarningDemo } from './control-warning.demo';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ClarityModule,
+    ClrCommonFormsModule,
+    ClrAddonsModule,
+    FormsModule,
+    ReactiveFormsModule,
+    RouterModule.forChild([{ path: '', component: ControlWarningDemo }]),
+  ],
+  declarations: [ControlWarningDemo],
+  exports: [ControlWarningDemo],
+})
+export class ControlWarningDemoModule {}

--- a/src/dev/src/app/control-warning/control-warning.demo.scss
+++ b/src/dev/src/app/control-warning/control-warning.demo.scss
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+.time-width {
+  flex: 0 0 13%;
+  max-width: 13%;
+}

--- a/src/dev/src/app/control-warning/control-warning.demo.ts
+++ b/src/dev/src/app/control-warning/control-warning.demo.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018-2026 Porsche Informatik. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import { AfterViewInit, Component } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { of } from 'rxjs';
+import { delay } from 'rxjs/operators';
+
+@Component({
+  selector: 'clr-control-warning-demo',
+  templateUrl: './control-warning.demo.html',
+  styleUrl: './control-warning.demo.scss',
+  standalone: false,
+})
+export class ControlWarningDemo implements AfterViewInit {
+  values$ = of([
+    'Option 4',
+    '<na> Option 5',
+    'Option 6 (test)Option 6 (test)Option 6 (test)Option 6 (test)',
+    'Option 7',
+  ]).pipe(delay(500));
+
+  date: any;
+  time: any;
+  showingInputWarnings = false;
+  isInputFormValidating = false;
+  comboBoxWarningString = ' This warning icon was displayed before the error';
+
+  inputForm: FormGroup = new FormGroup<any>({
+    input: new FormControl(),
+    textArea: new FormControl(),
+    select: new FormControl(),
+    date: new FormControl(),
+    time: new FormControl(),
+    comboSingle: new FormControl(),
+    checkbox: new FormControl(),
+  });
+
+  ngAfterViewInit(): void {
+    this.isInputFormValidating = true;
+    this.inputForm.reset();
+  }
+
+  validateInputForm() {
+    this.inputForm.markAllAsTouched();
+  }
+
+  toggleInputFormValidation() {
+    this.isInputFormValidating = !this.isInputFormValidating;
+    if (!this.isInputFormValidating) {
+      if (!this.showingInputWarnings) {
+        this.comboBoxWarningString = ' This warning icon was displayed after the error';
+      }
+      this.validateInputForm();
+    } else {
+      this.comboBoxWarningString = ' This warning icon was displayed before the error';
+
+      this.inputForm.reset();
+    }
+  }
+
+  showTextInputWarnings() {
+    this.showingInputWarnings = !this.showingInputWarnings;
+  }
+}


### PR DESCRIPTION
Clarity 18 changed the display of form validations, this brings the warning styling in line with that

Before this fix
<img width="1017" height="1274" alt="image" src="https://github.com/user-attachments/assets/6246302c-0657-49de-a596-5cc3b3c53b76" />


After
<img width="1369" height="1172" alt="image" src="https://github.com/user-attachments/assets/8111f962-872f-45fc-91e2-bcab58308131" />
