### PR TITLE
Fix data-testid override on treetable columns and cells

### DIFF
--- a/src/clr-addons/treetable/treetable-cell.ts
+++ b/src/clr-addons/treetable/treetable-cell.ts
@@ -4,17 +4,23 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostAttributeToken, inject } from '@angular/core';
 
 @Component({
   selector: 'clr-tt-cell',
   template: '<ng-content></ng-content>',
   host: {
     '[class.treetable-cell]': 'true',
-    'data-testid': 'treetable-cell',
+    '[attr.data-testid]': 'dataTestId',
     role: 'gridcell',
   },
   standalone: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ClrTreetableCell {}
+export class ClrTreetableCell {
+  /* Keep a data-testid set by the consumer, and only fall back to the default when none was provided. */
+  private readonly _userDataTestId = inject(new HostAttributeToken('data-testid'), { optional: true });
+  protected get dataTestId(): string {
+    return this._userDataTestId ?? 'treetable-cell';
+  }
+}

--- a/src/clr-addons/treetable/treetable-column.ts
+++ b/src/clr-addons/treetable/treetable-column.ts
@@ -9,6 +9,7 @@ import {
   Component,
   computed,
   effect,
+  HostAttributeToken,
   inject,
   input,
   OnDestroy,
@@ -61,7 +62,7 @@ let columnId = 0;
   host: {
     '[class.treetable-column]': 'true',
     '[attr.aria-sort]': 'ariaSort()',
-    '[attr.data-testid]': '"treetable-column-" + columnId',
+    '[attr.data-testid]': 'dataTestId',
     role: 'columnheader',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -69,6 +70,12 @@ let columnId = 0;
 })
 export class ClrTreetableColumn<T extends object> implements OnInit, OnDestroy {
   public readonly columnId = `clr-tt-col-${columnId++}`;
+
+  /* Keep a data-testid set by the consumer, and only fall back to the default when none was provided. */
+  private readonly _userDataTestId = inject(new HostAttributeToken('data-testid'), { optional: true });
+  protected get dataTestId(): string {
+    return this._userDataTestId ?? `treetable-column-${this.columnId}`;
+  }
 
   private readonly _columnTitleRef = viewChild('columnTitle', { read: TemplateRef });
   private readonly _columnState = inject(TreetableColumnStateService);


### PR DESCRIPTION
The data-testid host bindings on clr-tt-column and clr-tt-cell            
unconditionally overwrote any data-testid a consuming application set on  
these elements (e.g. "my-column" became "treetable-column-clr-tt-col-12").
This broke consumers' existing tests and was unexpected behavior.         
                                                                          
Both components now read a consumer-provided data-testid via              
HostAttributeToken and only fall back to the generated/default value when 
none was set, so the consumer's own test id always takes precedence.      