### PR TITLE
[C3DEV-670984](C3DEV-670985) Fixes resizing of treetable columns

### DIFF
--- a/src/clr-addons/treetable/treetable-column.ts
+++ b/src/clr-addons/treetable/treetable-column.ts
@@ -8,7 +8,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  effect,
   HostAttributeToken,
   inject,
   input,

--- a/src/clr-addons/treetable/treetable-column.ts
+++ b/src/clr-addons/treetable/treetable-column.ts
@@ -8,7 +8,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  effect,
   inject,
   input,
   OnDestroy,
@@ -19,7 +18,7 @@ import {
 import { outputFromObservable, takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ClrPopoverService } from '@clr/angular';
 import { combineLatest, map } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { distinctUntilChanged, filter } from 'rxjs/operators';
 import { ClrTreetableSortOrder } from './enums/sort-order.enum';
 import { SortStateService } from './providers';
 import { TreetableColumnStateService, TreetableColumnUpdate } from './providers/treetable-column-state.service';
@@ -173,12 +172,15 @@ export class ClrTreetableColumn<T extends object> implements OnInit, OnDestroy {
         }
       });
 
-    effect(() => {
-      const size = this.clrTtColumnSize();
-      if (size) {
+    toObservable(this.clrTtColumnSize)
+      .pipe(
+        filter(size => size != null),
+        distinctUntilChanged(),
+        takeUntilDestroyed()
+      )
+      .subscribe(size => {
         this._columnState.changeWidth(this.columnId, size);
-      }
-    });
+      });
   }
 
   protected sort(reverse?: boolean) {

--- a/src/clr-addons/treetable/treetable.scss
+++ b/src/clr-addons/treetable/treetable.scss
@@ -469,6 +469,7 @@ $cell-min-width: var(--cds-global-space-12);
             .treetable-column-resize-tracker {
               position: absolute;
               top: calc(-1 * var(--cds-global-space-6));
+              right: 0;
               display: none;
               width: var(--cds-global-space-1);
               height: 0;

--- a/src/dev/src/app/treetable/treetable.demo.html
+++ b/src/dev/src/app/treetable/treetable.demo.html
@@ -45,7 +45,7 @@
     </ng-template>
     <clr-tt-string-filter [clrTtStringFilter]="treeIdFilter"></clr-tt-string-filter>
   </clr-tt-column>
-  <clr-tt-column>
+  <clr-tt-column [clrTtColumnSize]="250">
     <ng-content *clrTtHideableColumn="testHidable()">Parent</ng-content>
   </clr-tt-column>
   <clr-tt-column>
@@ -83,6 +83,7 @@
   <clr-dg-column
     [clrDgSortBy]="datagridComperator"
     [clrDgSortOrder]="datagridSortOrder"
+    [style.width.px]="nameColumnWidth()"
     (clrDgColumnResize)="logValues('datagrid', $event)"
   >
     <ng-container *clrDgHideableColumn="{ hidden: false }">A Really Long Name</ng-container>
@@ -92,7 +93,7 @@
     <ng-container *clrDgHideableColumn="{ hidden: testHidden() }">ID</ng-container>
     <clr-dg-string-filter [clrDgStringFilter]="datagridTreeIdFilter"></clr-dg-string-filter>
   </clr-dg-column>
-  <clr-dg-column>
+  <clr-dg-column [style.width.px]="250">
     <ng-container *clrDgHideableColumn="{ hidden: testHidden() }">Parent</ng-container>
   </clr-dg-column>
   <clr-dg-column>


### PR DESCRIPTION
- Fixes resizing for columns that only set a custom width with the [clrTtColumnSize] attribute and do not use the (clrTtColumnResize) output.