### PR TITLE
Fix data-testid override on treetable columns and cells

### DIFF
--- a/src/clr-addons/treetable/treetable-cell.ts
+++ b/src/clr-addons/treetable/treetable-cell.ts
@@ -23,17 +23,7 @@ export class ClrTreetableCell implements AfterViewInit {
   private readonly _renderer = inject(Renderer2);
 
   ngAfterViewInit(): void {
-    /*
-     * Only apply a default data-testid when the consumer hasn't provided one.
-     * This is intentionally checked against the live DOM attribute (after the
-     * consumer's own bindings have been applied) instead of using
-     * HostAttributeToken, because HostAttributeToken can only see attribute
-     * values that are static string literals at compile time. It cannot see
-     * values set via [attr.data-testid]="expr", which is required whenever a
-     * consumer needs a unique testid per cell (e.g. inside an @for loop).
-     * Also, unlike a reactive host binding, this only runs once and never
-     * overwrites a value the consumer has set afterwards.
-     */
+    // Only set a default testid if the consumer didn't already provide one.
     const host = this._elementRef.nativeElement;
     if (!host.hasAttribute('data-testid')) {
       this._renderer.setAttribute(host, 'data-testid', DEFAULT_TEST_ID);

--- a/src/clr-addons/treetable/treetable-cell.ts
+++ b/src/clr-addons/treetable/treetable-cell.ts
@@ -4,23 +4,39 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { ChangeDetectionStrategy, Component, HostAttributeToken, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, inject, Renderer2 } from '@angular/core';
+
+const DEFAULT_TEST_ID = 'treetable-cell';
 
 @Component({
   selector: 'clr-tt-cell',
   template: '<ng-content></ng-content>',
   host: {
     '[class.treetable-cell]': 'true',
-    '[attr.data-testid]': 'dataTestId',
     role: 'gridcell',
   },
   standalone: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ClrTreetableCell {
-  /* Keep a data-testid set by the consumer, and only fall back to the default when none was provided. */
-  private readonly _userDataTestId = inject(new HostAttributeToken('data-testid'), { optional: true });
-  protected get dataTestId(): string {
-    return this._userDataTestId ?? 'treetable-cell';
+export class ClrTreetableCell implements AfterViewInit {
+  private readonly _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly _renderer = inject(Renderer2);
+
+  ngAfterViewInit(): void {
+    /*
+     * Only apply a default data-testid when the consumer hasn't provided one.
+     * This is intentionally checked against the live DOM attribute (after the
+     * consumer's own bindings have been applied) instead of using
+     * HostAttributeToken, because HostAttributeToken can only see attribute
+     * values that are static string literals at compile time. It cannot see
+     * values set via [attr.data-testid]="expr", which is required whenever a
+     * consumer needs a unique testid per cell (e.g. inside an @for loop).
+     * Also, unlike a reactive host binding, this only runs once and never
+     * overwrites a value the consumer has set afterwards.
+     */
+    const host = this._elementRef.nativeElement;
+    if (!host.hasAttribute('data-testid')) {
+      this._renderer.setAttribute(host, 'data-testid', DEFAULT_TEST_ID);
+    }
   }
 }

--- a/src/clr-addons/treetable/treetable-column.ts
+++ b/src/clr-addons/treetable/treetable-column.ts
@@ -5,14 +5,16 @@
  */
 
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   computed,
-  HostAttributeToken,
+  ElementRef,
   inject,
   input,
   OnDestroy,
   OnInit,
+  Renderer2,
   TemplateRef,
   viewChild,
 } from '@angular/core';
@@ -61,21 +63,16 @@ let columnId = 0;
   host: {
     '[class.treetable-column]': 'true',
     '[attr.aria-sort]': 'ariaSort()',
-    '[attr.data-testid]': 'dataTestId',
     role: 'columnheader',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
-export class ClrTreetableColumn<T extends object> implements OnInit, OnDestroy {
+export class ClrTreetableColumn<T extends object> implements OnInit, OnDestroy, AfterViewInit {
   public readonly columnId = `clr-tt-col-${columnId++}`;
 
-  /* Keep a data-testid set by the consumer, and only fall back to the default when none was provided. */
-  private readonly _userDataTestId = inject(new HostAttributeToken('data-testid'), { optional: true });
-  protected get dataTestId(): string {
-    return this._userDataTestId ?? `treetable-column-${this.columnId}`;
-  }
-
+  private readonly _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly _renderer = inject(Renderer2);
   private readonly _columnTitleRef = viewChild('columnTitle', { read: TemplateRef });
   private readonly _columnState = inject(TreetableColumnStateService);
   private readonly _sort = inject(SortStateService<T>);
@@ -127,6 +124,22 @@ export class ClrTreetableColumn<T extends object> implements OnInit, OnDestroy {
 
   ngOnInit() {
     this._columnState.register({ id: this.columnId, titleTemplateRef: this._columnTitleRef() });
+  }
+
+  ngAfterViewInit(): void {
+    /*
+     * Only apply a default data-testid when the consumer hasn't provided one.
+     * See ClrTreetableCell for why this is checked against the live DOM
+     * attribute instead of using HostAttributeToken: HostAttributeToken can
+     * only read attribute values that are static string literals at compile
+     * time, not values set via [attr.data-testid], which is required for a
+     * unique testid per column inside an @for loop. This also runs only
+     * once, so it never overwrites a value set by the consumer.
+     */
+    const host = this._elementRef.nativeElement;
+    if (!host.hasAttribute('data-testid')) {
+      this._renderer.setAttribute(host, 'data-testid', `treetable-column-${this.columnId}`);
+    }
   }
 
   ngOnDestroy() {

--- a/src/clr-addons/treetable/treetable-column.ts
+++ b/src/clr-addons/treetable/treetable-column.ts
@@ -127,15 +127,7 @@ export class ClrTreetableColumn<T extends object> implements OnInit, OnDestroy, 
   }
 
   ngAfterViewInit(): void {
-    /*
-     * Only apply a default data-testid when the consumer hasn't provided one.
-     * See ClrTreetableCell for why this is checked against the live DOM
-     * attribute instead of using HostAttributeToken: HostAttributeToken can
-     * only read attribute values that are static string literals at compile
-     * time, not values set via [attr.data-testid], which is required for a
-     * unique testid per column inside an @for loop. This also runs only
-     * once, so it never overwrites a value set by the consumer.
-     */
+    // Only set a default testid if the consumer didn't already provide one.
     const host = this._elementRef.nativeElement;
     if (!host.hasAttribute('data-testid')) {
       this._renderer.setAttribute(host, 'data-testid', `treetable-column-${this.columnId}`);


### PR DESCRIPTION
- The previous fix (#3009) did not work for dynamic test ids provided via [attr.data-testid]