### PR TITLE
Fix: Filter out unordered columns in tables when the order attribute does not exist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clr-addons",
-  "version": "21.5.3",
+  "version": "21.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clr-addons",
-      "version": "21.5.3",
+      "version": "21.5.4",
       "dependencies": {
         "@angular/animations": "21.2.20",
         "@angular/cdk": "21.2.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-addons",
-  "version": "21.5.3",
+  "version": "21.5.4",
   "private": true,
   "scripts": {
     "build:ui:css": "sass --source-map --precision=8 ./src/clr-addons/themes/phs/phs-theme.scss ./dist/clr-addons/styles/clr-addons-phs.css",

--- a/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.directive.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.directive.ts
@@ -227,7 +227,9 @@ export class StatePersistenceKeyDirective implements AfterContentInit, OnDestroy
 
   private initColumnOrder(savedState: ClrDatagridStatePersistenceModel): void {
     if (savedState?.columns) {
-      const entries = Object.entries(savedState.columns).map(([key, value]) => [key, value.order] as const);
+      const entries = Object.entries(savedState.columns)
+        .filter(([, value]) => typeof value.order === 'number')
+        .map(([key, value]) => [key, value.order] as const);
       this.reorderDirective.initializeColumnOrder(Object.fromEntries(entries));
     }
   }

--- a/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.spec.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.spec.ts
@@ -30,16 +30,18 @@ import { ClrDatagridStatePersistenceModel } from './datagrid-state-persistence-m
         persistSort,
         persistColumnWidths,
         persistColumnOrder,
-        persistColumnOrderTransformer
+        persistColumnOrderTransformer,
       }"
       [clrPaginationDescription]="'{{first}} - {{last}} of {{total}} entries'"
       [clrDatagridColumnReorder]="columns"
       (clrDatagridColumnOrderChanged)="columns = $event.columns"
       (clrDgRefresh)="refreshHandler.next($event)"
     >
-      <clr-dg-column *ngFor="let col of columns" [clrDgField]="col.name" cdkDrag>
-        <ng-container *clrDgHideableColumn="{ hidden: col.hidden }">{{ col.title }}</ng-container>
-      </clr-dg-column>
+      @for (col of columns; track col.name) {
+        <clr-dg-column [clrDgField]="col.name" cdkDrag>
+          <ng-container *clrDgHideableColumn="{ hidden: col.hidden }">{{ col.title }}</ng-container>
+        </clr-dg-column>
+      }
       <clr-dg-column id="column1" [clrDgField]="'column1'" [clrDgSortBy]="'column1'">
         <ng-template clrDgHideableColumn><span>column1</span></ng-template>
       </clr-dg-column>

--- a/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.spec.ts
+++ b/src/clr-addons/datagrid/datagrid-state-persistence/state-persistence-key.spec.ts
@@ -30,18 +30,16 @@ import { ClrDatagridStatePersistenceModel } from './datagrid-state-persistence-m
         persistSort,
         persistColumnWidths,
         persistColumnOrder,
-        persistColumnOrderTransformer,
+        persistColumnOrderTransformer
       }"
       [clrPaginationDescription]="'{{first}} - {{last}} of {{total}} entries'"
       [clrDatagridColumnReorder]="columns"
       (clrDatagridColumnOrderChanged)="columns = $event.columns"
       (clrDgRefresh)="refreshHandler.next($event)"
     >
-      @for (col of columns; track col.name) {
-        <clr-dg-column [clrDgField]="col.name" cdkDrag>
-          <ng-container *clrDgHideableColumn="{ hidden: col.hidden }">{{ col.title }}</ng-container>
-        </clr-dg-column>
-      }
+      <clr-dg-column *ngFor="let col of columns" [clrDgField]="col.name" cdkDrag>
+        <ng-container *clrDgHideableColumn="{ hidden: col.hidden }">{{ col.title }}</ng-container>
+      </clr-dg-column>
       <clr-dg-column id="column1" [clrDgField]="'column1'" [clrDgSortBy]="'column1'">
         <ng-template clrDgHideableColumn><span>column1</span></ng-template>
       </clr-dg-column>
@@ -130,6 +128,7 @@ describe('StatePersistenceKeyDirective', () => {
         CdkDrag,
       ],
       declarations: [TestComponent],
+      teardown: { destroyAfterEach: false },
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponent);
@@ -492,6 +491,19 @@ describe('StatePersistenceKeyDirective', () => {
     it('should init column order if enabled', () => {
       const storageKey = PERSISTENCE_KEY + '-should-init-order';
       localStorage.setItem(storageKey, '{"columns":{"dynamic-column-2":{"order":0},"dynamic-column-1":{"order":1}}}');
+      fixture.componentInstance.persistColumnOrder = true;
+      fixture.componentInstance.storageKey = storageKey;
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.columns.map(c => c.name)).toEqual(['dynamic-column-2', 'dynamic-column-1']);
+    });
+
+    it('should ignore columns without order when initializing column order', () => {
+      const storageKey = PERSISTENCE_KEY + '-should-ignore-columns-without-order';
+      localStorage.setItem(
+        storageKey,
+        '{"columns":{"dynamic-column-2":{"order":0},"dynamic-column-1":{"width":"118px"}}}'
+      );
       fixture.componentInstance.persistColumnOrder = true;
       fixture.componentInstance.storageKey = storageKey;
       fixture.detectChanges();

--- a/src/clr-addons/package.json
+++ b/src/clr-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/clr-addons",
-  "version": "21.5.3",
+  "version": "21.5.4",
   "description": "Addon components for Clarity Angular",
   "homepage": "https://porscheinformatik.github.io/clarity-addons/",
   "keywords": [

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -50,7 +50,7 @@
     },
     "../dist/clr-addons": {
       "name": "@porscheinformatik/clr-addons",
-      "version": "21.5.3",
+      "version": "21.5.4",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"


### PR DESCRIPTION
Fix: Filter out unordered columns in tables when the order attribute does not exist
