### PR TITLE
Fix time input width (not wide enough to show dropdown entry point)

### DIFF
--- a/src/clr-addons/components.clr-addons.scss
+++ b/src/clr-addons/components.clr-addons.scss
@@ -411,7 +411,7 @@ clr-date-container .clr-control-container {
 
 //Set the width of all inputs by type
 .clr-input-group:has(input[type='time']) {
-  max-width: 4rem;
+  max-width: 5rem;
 }
 
 // Set the width of text areas and selects to 100%

--- a/website/src/app/documentation/demos/forms/forms.demo.html
+++ b/website/src/app/documentation/demos/forms/forms.demo.html
@@ -140,6 +140,7 @@
             [ngModelOptions]="{ updateOn: 'blur' }"
             name="time"
             clrInput
+            clrTime
           />
         </clr-input-container>
         <clr-date-time-container class="clr-col-12 clr-row">


### PR DESCRIPTION
At some point a width of 4 rem was set for the time input (specifically only when used within a `clr-input-container`, not a `clr-date-time-container`), which was cutting off the clock icon and not allowing the user to select a time from the dropdown. This PR bumps the width up to 5 rem, which is enough to render the whole component. Inputs within a `clr-date-time-container` are not affected, as they aren't targeted by the css selector.

Before: 
<img width="354" height="75" alt="image" src="https://github.com/user-attachments/assets/8fe50ed2-b2d9-40f4-802a-f44c88ad02c6" />
After:
<img width="259" height="55" alt="image" src="https://github.com/user-attachments/assets/73dac2f4-42a0-4630-b657-abf5178e8db6" />
