### PR TITLE
fix(dot-pager): track @for by index to prevent NG0955 on Angular 21

### DIFF
--- a/src/clr-addons/dot-pager/dot-pager.html
+++ b/src/clr-addons/dot-pager/dot-pager.html
@@ -1,6 +1,6 @@
 @if (pages > 0) {
 <clr-radio-container clrInline>
-  @for (a of pageArray(); track a; let page = $index) {
+  @for (page of pageArray; track page) {
   <clr-radio-wrapper>
     <input
       clrRadio

--- a/src/clr-addons/dot-pager/dot-pager.ts
+++ b/src/clr-addons/dot-pager/dot-pager.ts
@@ -45,7 +45,7 @@ export class ClrDotPager {
     }
   }
 
-  pageArray(): any[] {
-    return Array(this._pages);
+  get pageArray(): number[] {
+    return [...Array(this._pages).keys()];
   }
 }


### PR DESCRIPTION
fix(dot-pager): track @for by index to prevent NG0955 on Angular 21

ClrDotPager rendered its dots with:
    @for (a of pageArray(); track a; let page = $index) { ... }
where pageArray() returns Array(this._pages).

On Angular 21, clr-dot-pager floods the console with NG0955 ("duplicated keys"). Cause: pageArray() returns Array(this.pages), a sparse array where slots all read as undefined, so tracking by value gives every dot the same key. Angular 21's @for requires unique keys (the old ngFor didn't).
Fix: return real indices ([...Array(this._pages).keys()]) and track by them.
