### PR TITLE
fix(datagrid): restore checkbox padding in enum filter

### DIFF
--- a/src/clr-addons/themes/phs/_css.overrides.scss
+++ b/src/clr-addons/themes/phs/_css.overrides.scss
@@ -321,5 +321,5 @@
 
 // Checkboxes inside datagrid enum filters shouldn't be cut off
 .datagrid-filter .clr-form-control {
-  padding: var(--clr-base-vertical-offset-multi-row-s)
+  padding: var(--clr-base-vertical-offset-multi-row-s);
 }

--- a/src/clr-addons/themes/phs/_css.overrides.scss
+++ b/src/clr-addons/themes/phs/_css.overrides.scss
@@ -318,3 +318,8 @@
 .datagrid-detail-pane .pagination {
   width: auto;
 }
+
+// Checkboxes inside datagrid enum filters shouldn't be cut off
+.datagrid-filter .clr-form-control {
+  padding: var(--clr-base-vertical-offset-multi-row-s)
+}


### PR DESCRIPTION
Checkbox options in the datagrid enum filter popover were clipped because .datagrid-filter .clr-form-control had no propper padding. Added --clr-base-vertical-offset-multi-row-s to restore spacing.

Before:
<img width="252" height="227" alt="image" src="https://github.com/user-attachments/assets/3464c9a6-476f-4b93-9305-7c4177745d0d" />

After:
<img width="257" height="211" alt="image" src="https://github.com/user-attachments/assets/1664338d-b1ee-4932-a283-4f056e708496" />
