### PR TITLE
Set min-width on sortable/filterable datagrid columns & cells

### DIFF
--- a/src/clr-addons/themes/phs/_css.overrides.scss
+++ b/src/clr-addons/themes/phs/_css.overrides.scss
@@ -323,3 +323,9 @@
 .datagrid-filter .clr-form-control {
   padding: var(--clr-base-vertical-offset-multi-row-s);
 }
+
+// Ensure datagrid columns with sort icons or filter toggles have enough width to display them properly
+.datagrid-table .datagrid-column:has(.sort-icon),
+.datagrid-table .datagrid-column:has(.datagrid-filter-toggle) {
+  min-width: calc(2 * var(--cds-global-space-15)) !important;
+}

--- a/src/clr-addons/themes/phs/_css.overrides.scss
+++ b/src/clr-addons/themes/phs/_css.overrides.scss
@@ -324,8 +324,9 @@
   padding: var(--clr-base-vertical-offset-multi-row-s);
 }
 
-// Ensure datagrid columns with sort icons or filter toggles have enough width to display them properly
-.datagrid-table .datagrid-column:has(.sort-icon),
-.datagrid-table .datagrid-column:has(.datagrid-filter-toggle) {
+// Keep every column and cell at the same min-width so headers and cells stay aligned and
+// sortable/filterable columns still have room for their icons (fixed-width columns opt out)
+.datagrid-table .datagrid-column:not(.datagrid-fixed-column),
+.datagrid-table .datagrid-cell:not(.datagrid-fixed-column) {
   min-width: calc(2 * var(--cds-global-space-15)) !important;
 }


### PR DESCRIPTION
Enforce a minimum width on datagrid columns that contain a sort icon or filter button so their headers don't get squeezed.

Before:
<img width="1916" height="533" alt="image" src="https://github.com/user-attachments/assets/417797d7-f32c-40dc-bb70-c682148eddd5" />

After:
<img width="2550" height="834" alt="image" src="https://github.com/user-attachments/assets/6ee69d9c-e4c1-451b-be48-409c51c240d0" />
